### PR TITLE
Initial state entry action fix

### DIFF
--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -168,7 +168,7 @@ class MachineDefinition
             return null;
         }
 
-        // Run entry actions on the target state definition
+        // Run entry actions on the initial state definition
         $this->initial->runEntryActions();
 
         return new State(

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -168,6 +168,9 @@ class MachineDefinition
             return null;
         }
 
+        // Run entry actions on the target state definition
+        $this->initial->runEntryActions();
+
         return new State(
             activeStateDefinition: $this->initial,
             contextData: $this->context->toArray(),

--- a/src/Definition/StateDefinition.php
+++ b/src/Definition/StateDefinition.php
@@ -391,7 +391,7 @@ class StateDefinition
      *
      * @param  \Tarfinlabs\EventMachine\Behavior\EventBehavior|null  $eventBehavior  The event to be processed.
      */
-    public function runEntryActions(?EventBehavior $eventBehavior): void
+    public function runEntryActions(?EventBehavior $eventBehavior = null): void
     {
         foreach ($this->entry as $action) {
             $this->machine->runAction($action, $eventBehavior);

--- a/tests/EntryActionsTest.php
+++ b/tests/EntryActionsTest.php
@@ -45,34 +45,3 @@ it('should run entry actions when transitioning to a new state', function (): vo
     // Ensure that the machine's context has been changed.
     expect($machine->context->get('count'))->toBe(1);
 });
-
-it('should run entry actions for initial state when machine invoke up', function (): void {
-    $machine = MachineDefinition::define(
-        config: [
-            'initial' => 'active',
-            'context' => [
-                'count' => 0,
-            ],
-            'states' => [
-                'active' => [
-                    'entry' => 'incrementAction',
-                ],
-            ],
-        ],
-        behavior: [
-            'actions' => [
-                'incrementAction' => function (ContextManager $context): void {
-                    $context->set('count', $context->get('count') + 1);
-                },
-            ],
-        ],
-    );
-
-    expect($machine->initialState)
-        ->toBeInstanceOf(State::class)
-        ->and($machine->initialState->value)->toBe(['active']);
-    expect($machine->initialState->contextData)->toBe(['count' => 1]);
-
-    // Ensure that the machine's context has been changed.
-    expect($machine->context->get('count'))->toBe(1);
-});

--- a/tests/EntryActionsTest.php
+++ b/tests/EntryActionsTest.php
@@ -45,3 +45,34 @@ it('should run entry actions when transitioning to a new state', function (): vo
     // Ensure that the machine's context has been changed.
     expect($machine->context->get('count'))->toBe(1);
 });
+
+it('should run entry actions for initial state when machine invoke up', function (): void {
+    $machine = MachineDefinition::define(
+        config: [
+            'initial' => 'active',
+            'context' => [
+                'count' => 0,
+            ],
+            'states' => [
+                'active' => [
+                    'entry' => 'incrementAction',
+                ],
+            ],
+        ],
+        behavior: [
+            'actions' => [
+                'incrementAction' => function (ContextManager $context): void {
+                    $context->set('count', $context->get('count') + 1);
+                },
+            ],
+        ],
+    );
+
+    expect($machine->initialState)
+        ->toBeInstanceOf(State::class)
+        ->and($machine->initialState->value)->toBe(['active']);
+    expect($machine->initialState->contextData)->toBe(['count' => 1]);
+
+    // Ensure that the machine's context has been changed.
+    expect($machine->context->get('count'))->toBe(1);
+});

--- a/tests/InitialStateTest.php
+++ b/tests/InitialStateTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Tarfinlabs\EventMachine\Actor\State;
+use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Definition\StateDefinition;
 use Tarfinlabs\EventMachine\Definition\MachineDefinition;
 
@@ -67,4 +69,33 @@ test('the first state definition is set as the initial state for both top-level 
     expect($machine->states['green']->states['walk']->initial)->toBeNull();
     expect($machine->states['green']->states['wait']->initial)->toBeNull();
     expect($machine->states['green']->states['stop']->initial)->toBeNull();
+});
+
+it('should run entry actions for building initial state', function (): void {
+    $machine = MachineDefinition::define(
+        config: [
+            'initial' => 'active',
+            'context' => [
+                'count' => 0,
+            ],
+            'states' => [
+                'active' => [
+                    'entry' => 'incrementAction',
+                ],
+            ],
+        ],
+        behavior: [
+            'actions' => [
+                'incrementAction' => function (ContextManager $context): void {
+                    $context->set('count', $context->get('count') + 1);
+                },
+            ],
+        ],
+    );
+
+    expect($machine)
+        ->initialState->toBeInstanceOf(State::class)
+        ->initialState->value->toBe(['active'])
+        ->initialState->contextData->toBe(['count' => 1])
+        ->context->get('count')->toBe(1);
 });

--- a/tests/InitialStateTest.php
+++ b/tests/InitialStateTest.php
@@ -96,6 +96,6 @@ it('should run entry actions for building initial state', function (): void {
     expect($machine)
         ->initialState->toBeInstanceOf(State::class)
         ->initialState->value->toBe(['active'])
-        ->initialState->contextData->toBe(['count' => 1])
-        ->context->get('count')->toBe(1);
+        ->context->get('count')->toBe(1)
+        ->and($machine->initialState->context['data']['count'])->toBe(1);
 });


### PR DESCRIPTION
### Changed
- The default value of `$eventBehavior` in the `runEntryActions` method is set to `null`
- `runEntryActions` method is called for `initial` state definition in `buildInitialState`
