### PR TITLE
feat: Add `version` property to `EventBehavior` (WEB-3699)

### DIFF
--- a/src/Behavior/EventBehavior.php
+++ b/src/Behavior/EventBehavior.php
@@ -12,6 +12,7 @@ abstract class EventBehavior extends Data
     public function __construct(
         public null|string|Optional $type = null,
         public null|array|Optional $payload = null,
+        public int $version = 1,
     ) {
         if ($this->type === null) {
             $this->type = static::getType();

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Tarfinlabs\EventMachine\Behavior\EventBehavior;
+
+test('an event has a version', function (): void {
+    $eventWithoutExplicitVersionDefinition = new class() extends EventBehavior {
+        public static function getType(): string
+        {
+            return 'TEST_EVENT';
+        }
+    };
+
+    $eventWithVersionDefinition = new class(version: 13) extends EventBehavior {
+        public static function getType(): string
+        {
+            return 'TEST_EVENT';
+        }
+    };
+
+    expect($eventWithoutExplicitVersionDefinition->version)->toBe(1);
+    expect($eventWithVersionDefinition->version)->toBe(13);
+});


### PR DESCRIPTION
This commit adds a `version` property to the `EventBehavior` class in the `Behavior/EventBehavior.php` file. The `version` property allows specifying the version of an event.

- Added a new property `version` with type `int` to the `EventBehavior` class.
- Updated the constructor to accept the `version` parameter.
- Added a default value of `1` for the `version` property.
- Created a new test file `tests/EventTest.php` to test the `version` property of events.
- Added a test to check that events without an explicit version definition have a default version of `1`.
- Added a test to check that events with an explicit version definition have the specified version.