### PR TITLE
feat: Update `EventBehavior` constructor with optional `version` parameter (WEB-3701)

### DIFF
--- a/src/Behavior/EventBehavior.php
+++ b/src/Behavior/EventBehavior.php
@@ -12,7 +12,7 @@ abstract class EventBehavior extends Data
     public function __construct(
         public null|string|Optional $type = null,
         public null|array|Optional $payload = null,
-        public int $version = 1,
+        public int|Optional $version = 1,
     ) {
         if ($this->type === null) {
             $this->type = static::getType();


### PR DESCRIPTION
feat: Update `EventBehavior` constructor with optional `version` parameter (WEB-3701)

This commit updates the constructor of the `EventBehavior` class in the `Behavior/EventBehavior.php` file. The constructor now includes an optional `version` parameter, allowing flexibility in specifying the version of an event.

- Added an optional parameter `version` of type `int` to the `EventBehavior` constructor.
- The `version` parameter defaults to `1` if not provided.
- This change provides more flexibility when creating instances of `EventBehavior` by allowing the version to be optionally specified.