### PR TITLE
WEB-3703: Introduce Internal Events

### DIFF
--- a/database/migrations/create_machine_table.php.stub
+++ b/database/migrations/create_machine_table.php.stub
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->json('machine_value');
             $table->ulid('root_event_id')->nullable();
 
+            $table->string('source');
             $table->string('type');
             $table->json('payload');
             $table->unsignedInteger('version');

--- a/src/Actor/State.php
+++ b/src/Actor/State.php
@@ -10,6 +10,7 @@ use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Models\MachineEvent;
 use Tarfinlabs\EventMachine\Definition\SourceType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
+use Tarfinlabs\EventMachine\Definition\InternalEvent;
 use Tarfinlabs\EventMachine\Definition\EventDefinition;
 use Tarfinlabs\EventMachine\Definition\StateDefinition;
 
@@ -45,9 +46,9 @@ class State
         return $this;
     }
 
-    public function setInternalEventBehavior(string $type): self
+    public function setInternalEventBehavior(InternalEvent $type): self
     {
-        return $this->setEventBehavior(new EventDefinition(type: $type, source: SourceType::INTERNAL));
+        return $this->setEventBehavior(new EventDefinition(type: $type->value, source: SourceType::INTERNAL));
     }
 
     public function setEventBehavior(EventBehavior $eventBehavior): self

--- a/src/Actor/State.php
+++ b/src/Actor/State.php
@@ -8,7 +8,9 @@ use Symfony\Component\Uid\Ulid;
 use Illuminate\Support\Collection;
 use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Models\MachineEvent;
+use Tarfinlabs\EventMachine\Definition\SourceType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
+use Tarfinlabs\EventMachine\Definition\EventDefinition;
 use Tarfinlabs\EventMachine\Definition\StateDefinition;
 
 class State
@@ -41,6 +43,11 @@ class State
         $this->updateValueFromState();
 
         return $this;
+    }
+
+    public function setInternalEventBehavior(string $type): self
+    {
+        return $this->setEventBehavior(new EventDefinition(type: $type, source: SourceType::INTERNAL));
     }
 
     public function setEventBehavior(EventBehavior $eventBehavior): self

--- a/src/Actor/State.php
+++ b/src/Actor/State.php
@@ -46,9 +46,18 @@ class State
         return $this;
     }
 
-    public function setInternalEventBehavior(InternalEvent $type): self
-    {
-        return $this->setEventBehavior(new EventDefinition(type: $type->value, source: SourceType::INTERNAL));
+    public function setInternalEventBehavior(
+        InternalEvent $type,
+        ?string $placeholder = null,
+    ): self {
+        $eventDefinition = new EventDefinition(
+            type: $placeholder === null
+                ? $type->value
+                : sprintf($type->value, $placeholder),
+            source: SourceType::INTERNAL
+        );
+
+        return $this->setEventBehavior($eventDefinition);
     }
 
     public function setEventBehavior(EventBehavior $eventBehavior): self

--- a/src/Actor/State.php
+++ b/src/Actor/State.php
@@ -66,6 +66,7 @@ class State
                 $this->activeStateDefinition->id,
             ],
             'root_event_id' => $count === 1 ? $id : $this->history[0]->id,
+            'source'        => $eventBehavior->source->value,
             'type'          => $eventBehavior->type,
             'payload'       => $eventBehavior->payload,
             'version'       => $eventBehavior->version,

--- a/src/Actor/State.php
+++ b/src/Actor/State.php
@@ -50,10 +50,12 @@ class State
         InternalEvent $type,
         ?string $placeholder = null,
     ): self {
+        $type = ($placeholder === null)
+            ? $type->value
+            : sprintf($type->value, $placeholder);
+
         $eventDefinition = new EventDefinition(
-            type: $placeholder === null
-                ? $type->value
-                : sprintf($type->value, $placeholder),
+            type: $type,
             source: SourceType::INTERNAL
         );
 
@@ -76,7 +78,7 @@ class State
                 $this->activeStateDefinition->id,
             ],
             'root_event_id' => $count === 1 ? $id : $this->history[0]->id,
-            'source'        => $eventBehavior->source->value,
+            'source'        => $eventBehavior->source,
             'type'          => $eventBehavior->type,
             'payload'       => $eventBehavior->payload,
             'version'       => $eventBehavior->version,

--- a/src/Behavior/EventBehavior.php
+++ b/src/Behavior/EventBehavior.php
@@ -6,6 +6,7 @@ namespace Tarfinlabs\EventMachine\Behavior;
 
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Optional;
+use Tarfinlabs\EventMachine\Definition\SourceType;
 
 abstract class EventBehavior extends Data
 {
@@ -13,6 +14,7 @@ abstract class EventBehavior extends Data
         public null|string|Optional $type = null,
         public null|array|Optional $payload = null,
         public int|Optional $version = 1,
+        public SourceType|Optional $source = SourceType::EXTERNAL,
     ) {
         if ($this->type === null) {
             $this->type = static::getType();

--- a/src/Behavior/EventBehavior.php
+++ b/src/Behavior/EventBehavior.php
@@ -7,6 +7,7 @@ namespace Tarfinlabs\EventMachine\Behavior;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Optional;
 use Tarfinlabs\EventMachine\Definition\SourceType;
+use Spatie\LaravelData\Attributes\WithoutValidation;
 
 abstract class EventBehavior extends Data
 {
@@ -14,7 +15,9 @@ abstract class EventBehavior extends Data
         public null|string|Optional $type = null,
         public null|array|Optional $payload = null,
         public int|Optional $version = 1,
-        public SourceType|Optional $source = SourceType::EXTERNAL,
+
+        #[WithoutValidation]
+        public SourceType $source = SourceType::EXTERNAL,
     ) {
         if ($this->type === null) {
             $this->type = static::getType();

--- a/src/Definition/InternalEvent.php
+++ b/src/Definition/InternalEvent.php
@@ -9,4 +9,7 @@ enum InternalEvent: string
     case MACHINE_INIT = 'machine.init';
     case ACTION_INIT  = 'machine.action.%s.init';
     case ACTION_DONE  = 'machine.action.%s.done';
+    case GUARD_INIT   = 'machine.guard.%s.init';
+    case GUARD_FAIL   = 'machine.guard.%s.fail';
+    case GUARD_PASS   = 'machine.guard.%s.pass';
 }

--- a/src/Definition/InternalEvent.php
+++ b/src/Definition/InternalEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tarfinlabs\EventMachine\Definition;
+
+enum InternalEvent: string
+{
+    case MACHINE_INIT = 'machine.init';
+}

--- a/src/Definition/InternalEvent.php
+++ b/src/Definition/InternalEvent.php
@@ -7,4 +7,6 @@ namespace Tarfinlabs\EventMachine\Definition;
 enum InternalEvent: string
 {
     case MACHINE_INIT = 'machine.init';
+    case ACTION_INIT  = 'machine.action.%s.init';
+    case ACTION_DONE  = 'machine.action.%s.done';
 }

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -402,7 +402,6 @@ class MachineDefinition
      * executes it using the context and event payload.
      *
      * @param  string  $actionDefinition      The action definition, either a class
-     * @param  State  $state
      * @param  EventBehavior|null  $eventBehavior         The event (optional).
      */
     public function runAction(

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -416,11 +416,15 @@ class MachineDefinition
 
         // If the action behavior is callable, execute it with the context and event payload.
         if (is_callable($actionBehavior)) {
+            $state->setInternalEventBehavior("action.{$actionDefinition}.initial");
+
             // Execute the action behavior.
             $actionBehavior($context, $eventBehavior);
 
             // Validate the context after the action is executed.
             $context->selfValidate();
+
+            $state->setInternalEventBehavior("action.{$actionDefinition}.done");
         }
     }
 

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -403,13 +403,11 @@ class MachineDefinition
      * executes it using the context and event payload.
      *
      * @param  string  $actionDefinition      The action definition, either a class
-     * @param  ContextManager  $context
-     *                                                                                      name or an array key.
+     * @param  State  $state
      * @param  EventBehavior|null  $eventBehavior         The event (optional).
      */
     public function runAction(
         string $actionDefinition,
-        ContextManager $context,
         State $state,
         ?EventBehavior $eventBehavior = null
     ): void {
@@ -421,10 +419,10 @@ class MachineDefinition
             $state->setInternalEventBehavior("action.{$actionDefinition}.initial");
 
             // Execute the action behavior.
-            $actionBehavior($context, $eventBehavior);
+            $actionBehavior($state->context, $eventBehavior);
 
             // Validate the context after the action is executed.
-            $context->selfValidate();
+            $state->context->selfValidate();
 
             $state->setInternalEventBehavior("action.{$actionDefinition}.done");
         }

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -406,6 +406,7 @@ class MachineDefinition
     public function runAction(
         string $actionDefinition,
         ContextManager $context,
+        State $state,
         ?EventBehavior $eventBehavior = null
     ): void {
         // Retrieve the appropriate action behavior based on the action definition.

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -366,7 +366,7 @@ class MachineDefinition
         $transitionBranch->transitionDefinition->source->runExitActions($context, $state, $eventBehavior);
 
         // Run transition actions on the transition definition
-        $transitionBranch->runActions($context, $eventBehavior);
+        $transitionBranch->runActions($context, $state, $eventBehavior);
 
         // Run entry actions on the target state definition
         $transitionBranch->target?->runEntryActions($context, $state, $eventBehavior);

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -355,6 +355,7 @@ class MachineDefinition
         $transitionBranch = $transitionDefinition->getFirstValidTransitionBranch(
             eventBehavior: $eventBehavior,
             context: $context,
+            state: $state
         );
 
         // If the transition branch is not found, do nothing

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -151,9 +151,6 @@ class MachineDefinition
 
         $context = $this->initializeContextFromState();
 
-        // Run entry actions on the initial state definition
-        $this->initialStateDefinition->runEntryActions(context: $context);
-
         $initialState = $this->buildCurrentState(
             context: $context,
             currentStateDefinition: $this->initialStateDefinition,

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -371,7 +371,7 @@ class MachineDefinition
         $transitionBranch->transitionDefinition->source->runExitActions($state, $eventBehavior);
 
         // Run transition actions on the transition definition
-        $transitionBranch->runActions($context, $state, $eventBehavior);
+        $transitionBranch->runActions($state, $eventBehavior);
 
         // Run entry actions on the target state definition
         $transitionBranch->target?->runEntryActions($state, $eventBehavior);

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -159,7 +159,7 @@ class MachineDefinition
         $initialState->setInternalEventBehavior('machine.initial');
 
         // Run entry actions on the initial state definition
-        $this->initialStateDefinition->runEntryActions(context: $context, state: $initialState);
+        $this->initialStateDefinition->runEntryActions(state: $initialState);
 
         if ($initialStateDefinition->transitionDefinitions !== null) {
             foreach ($initialStateDefinition->transitionDefinitions as $transition) {
@@ -374,7 +374,7 @@ class MachineDefinition
         $transitionBranch->runActions($context, $state, $eventBehavior);
 
         // Run entry actions on the target state definition
-        $transitionBranch->target?->runEntryActions($context, $state, $eventBehavior);
+        $transitionBranch->target?->runEntryActions($state, $eventBehavior);
 
         $newState = $state
             ->setCurrentStateDefinition($transitionBranch->target ?? $currentStateDefinition);

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -368,7 +368,7 @@ class MachineDefinition
         }
 
         // Run exit actions on the source/current state definition
-        $transitionBranch->transitionDefinition->source->runExitActions($context, $state, $eventBehavior);
+        $transitionBranch->transitionDefinition->source->runExitActions($state, $eventBehavior);
 
         // Run transition actions on the transition definition
         $transitionBranch->runActions($context, $state, $eventBehavior);

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -363,7 +363,7 @@ class MachineDefinition
         }
 
         // Run exit actions on the source/current state definition
-        $transitionBranch->transitionDefinition->source->runExitActions($context, $eventBehavior);
+        $transitionBranch->transitionDefinition->source->runExitActions($context, $state, $eventBehavior);
 
         // Run transition actions on the transition definition
         $transitionBranch->runActions($context, $eventBehavior);

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -348,6 +348,9 @@ class MachineDefinition
 
         $eventBehavior = $this->initializeEvent($event, $currentStateDefinition);
 
+        // Set event behavior
+        $state->setEventBehavior($eventBehavior);
+
         // Find the transition definition for the event type
         /** @var null|array|TransitionDefinition $transitionDefinition */
         $transitionDefinition = $currentStateDefinition->transitionDefinitions[$eventBehavior->type] ?? null;
@@ -361,8 +364,7 @@ class MachineDefinition
         // If the transition branch is not found, do nothing
         if ($transitionBranch === null) {
             return $state
-                ->setCurrentStateDefinition($currentStateDefinition)
-                ->setEventBehavior($eventBehavior);
+                ->setCurrentStateDefinition($currentStateDefinition);
         }
 
         // Run exit actions on the source/current state definition
@@ -375,8 +377,7 @@ class MachineDefinition
         $transitionBranch->target?->runEntryActions($context, $state, $eventBehavior);
 
         $newState = $state
-            ->setCurrentStateDefinition($transitionBranch->target ?? $currentStateDefinition)
-            ->setEventBehavior($eventBehavior);
+            ->setCurrentStateDefinition($transitionBranch->target ?? $currentStateDefinition);
 
         if ($this->idMap[$newState->activeStateDefinition->id]->transitionDefinitions !== null) {
             // Check if the new state has any @always transitions

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -357,7 +357,6 @@ class MachineDefinition
 
         $transitionBranch = $transitionDefinition->getFirstValidTransitionBranch(
             eventBehavior: $eventBehavior,
-            context: $context,
             state: $state
         );
 

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -156,7 +156,7 @@ class MachineDefinition
             currentStateDefinition: $this->initialStateDefinition,
         );
 
-        $initialState->setInternalEventBehavior('machine.initial');
+        $initialState->setInternalEventBehavior(type: InternalEvent::MACHINE_INIT);
 
         // Run entry actions on the initial state definition
         $this->initialStateDefinition->runEntryActions(state: $initialState);

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -156,6 +156,8 @@ class MachineDefinition
             currentStateDefinition: $this->initialStateDefinition,
         );
 
+        $initialState->setInternalEventBehavior('machine.initial');
+
         // Run entry actions on the initial state definition
         $this->initialStateDefinition->runEntryActions(context: $context, state: $initialState);
 

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -159,6 +159,9 @@ class MachineDefinition
             currentStateDefinition: $this->initialStateDefinition,
         );
 
+        // Run entry actions on the initial state definition
+        $this->initialStateDefinition->runEntryActions(context: $context, state: $initialState);
+
         if ($initialStateDefinition->transitionDefinitions !== null) {
             foreach ($initialStateDefinition->transitionDefinitions as $transition) {
                 if ($transition->type === TransitionType::Always) {
@@ -369,7 +372,7 @@ class MachineDefinition
         $transitionBranch->runActions($context, $eventBehavior);
 
         // Run entry actions on the target state definition
-        $transitionBranch->target?->runEntryActions($context, $eventBehavior);
+        $transitionBranch->target?->runEntryActions($context, $state, $eventBehavior);
 
         $newState = $state
             ->setCurrentStateDefinition($transitionBranch->target ?? $currentStateDefinition)

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -156,6 +156,7 @@ class MachineDefinition
             currentStateDefinition: $this->initialStateDefinition,
         );
 
+        // Record the internal machine init event.
         $initialState->setInternalEventBehavior(type: InternalEvent::MACHINE_INIT);
 
         // Run entry actions on the initial state definition
@@ -416,6 +417,7 @@ class MachineDefinition
 
         // If the action behavior is callable, execute it with the context and event payload.
         if (is_callable($actionBehavior)) {
+            // Record the internal action init event.
             $state->setInternalEventBehavior(
                 type: InternalEvent::ACTION_INIT,
                 placeholder: $actionDefinition
@@ -427,6 +429,7 @@ class MachineDefinition
             // Validate the context after the action is executed.
             $state->context->selfValidate();
 
+            // Record the internal action done event.
             $state->setInternalEventBehavior(
                 type: InternalEvent::ACTION_DONE,
                 placeholder: $actionDefinition

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -401,8 +401,10 @@ class MachineDefinition
      * action definition, and if the action behavior is callable, it
      * executes it using the context and event payload.
      *
-     * @param  string  $actionDefinition      The action definition, either a class
-     * @param  EventBehavior|null  $eventBehavior         The event (optional).
+     * @param  string  $actionDefinition The action definition, either a class
+     * @param  EventBehavior|null  $eventBehavior The event (optional).
+     *
+     * @throws BehaviorNotFoundException
      */
     public function runAction(
         string $actionDefinition,
@@ -414,7 +416,10 @@ class MachineDefinition
 
         // If the action behavior is callable, execute it with the context and event payload.
         if (is_callable($actionBehavior)) {
-            $state->setInternalEventBehavior("action.{$actionDefinition}.initial");
+            $state->setInternalEventBehavior(
+                type: InternalEvent::ACTION_INIT,
+                placeholder: $actionDefinition
+            );
 
             // Execute the action behavior.
             $actionBehavior($state->context, $eventBehavior);
@@ -422,7 +427,10 @@ class MachineDefinition
             // Validate the context after the action is executed.
             $state->context->selfValidate();
 
-            $state->setInternalEventBehavior("action.{$actionDefinition}.done");
+            $state->setInternalEventBehavior(
+                type: InternalEvent::ACTION_DONE,
+                placeholder: $actionDefinition
+            );
         }
     }
 

--- a/src/Definition/SourceType.php
+++ b/src/Definition/SourceType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tarfinlabs\EventMachine\Definition;
+
+enum SourceType: string
+{
+    case INTERNAL = 'internal';
+    case EXTERNAL = 'external';
+}

--- a/src/Definition/StateDefinition.php
+++ b/src/Definition/StateDefinition.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tarfinlabs\EventMachine\Definition;
 
 use Tarfinlabs\EventMachine\Actor\State;
-use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Behavior\BehaviorType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
 
@@ -360,10 +359,10 @@ class StateDefinition
      *
      * @param  \Tarfinlabs\EventMachine\Behavior\EventBehavior  $eventBehavior  The event to be processed.
      */
-    public function runExitActions(ContextManager $context, State $state, EventBehavior $eventBehavior): void
+    public function runExitActions(State $state, EventBehavior $eventBehavior): void
     {
         foreach ($this->exit as $action) {
-            $this->machine->runAction($action, $context, $state, $eventBehavior);
+            $this->machine->runAction($action, $state, $eventBehavior);
         }
     }
 

--- a/src/Definition/StateDefinition.php
+++ b/src/Definition/StateDefinition.php
@@ -372,7 +372,7 @@ class StateDefinition
      *
      * @param  \Tarfinlabs\EventMachine\Behavior\EventBehavior|null  $eventBehavior  The event to be processed.
      */
-    public function runEntryActions(ContextManager $context, ?EventBehavior $eventBehavior = null): void
+    public function runEntryActions(ContextManager $context, State $state, ?EventBehavior $eventBehavior = null): void
     {
         foreach ($this->entry as $action) {
             $this->machine->runAction($action, $context, $eventBehavior);

--- a/src/Definition/StateDefinition.php
+++ b/src/Definition/StateDefinition.php
@@ -372,10 +372,10 @@ class StateDefinition
      *
      * @param  \Tarfinlabs\EventMachine\Behavior\EventBehavior|null  $eventBehavior  The event to be processed.
      */
-    public function runEntryActions(ContextManager $context, State $state, ?EventBehavior $eventBehavior = null): void
+    public function runEntryActions(State $state, ?EventBehavior $eventBehavior = null): void
     {
         foreach ($this->entry as $action) {
-            $this->machine->runAction($action, $context, $state, $eventBehavior);
+            $this->machine->runAction($action, $state, $eventBehavior);
         }
     }
 

--- a/src/Definition/StateDefinition.php
+++ b/src/Definition/StateDefinition.php
@@ -363,7 +363,7 @@ class StateDefinition
     public function runExitActions(ContextManager $context, State $state, EventBehavior $eventBehavior): void
     {
         foreach ($this->exit as $action) {
-            $this->machine->runAction($action, $context, $eventBehavior);
+            $this->machine->runAction($action, $context, $state, $eventBehavior);
         }
     }
 
@@ -375,7 +375,7 @@ class StateDefinition
     public function runEntryActions(ContextManager $context, State $state, ?EventBehavior $eventBehavior = null): void
     {
         foreach ($this->entry as $action) {
-            $this->machine->runAction($action, $context, $eventBehavior);
+            $this->machine->runAction($action, $context, $state, $eventBehavior);
         }
     }
 

--- a/src/Definition/StateDefinition.php
+++ b/src/Definition/StateDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tarfinlabs\EventMachine\Definition;
 
+use Tarfinlabs\EventMachine\Actor\State;
 use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Behavior\BehaviorType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
@@ -359,7 +360,7 @@ class StateDefinition
      *
      * @param  \Tarfinlabs\EventMachine\Behavior\EventBehavior  $eventBehavior  The event to be processed.
      */
-    public function runExitActions(ContextManager $context, EventBehavior $eventBehavior): void
+    public function runExitActions(ContextManager $context, State $state, EventBehavior $eventBehavior): void
     {
         foreach ($this->exit as $action) {
             $this->machine->runAction($action, $context, $eventBehavior);

--- a/src/Definition/TransitionBranch.php
+++ b/src/Definition/TransitionBranch.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tarfinlabs\EventMachine\Definition;
 
 use Tarfinlabs\EventMachine\Actor\State;
-use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Behavior\BehaviorType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
 
@@ -93,7 +92,6 @@ class TransitionBranch
      * @param  \Tarfinlabs\EventMachine\Behavior\EventBehavior|null  $eventBehavior  The event or null if none is provided.
      */
     public function runActions(
-        ContextManager $context,
         State $state,
         ?EventBehavior $eventBehavior = null
     ): void {
@@ -102,7 +100,7 @@ class TransitionBranch
         }
 
         foreach ($this->actions as $actionDefinition) {
-            $this->transitionDefinition->source->machine->runAction($actionDefinition, $context, $state, $eventBehavior);
+            $this->transitionDefinition->source->machine->runAction($actionDefinition, $state, $eventBehavior);
         }
     }
 

--- a/src/Definition/TransitionBranch.php
+++ b/src/Definition/TransitionBranch.php
@@ -102,7 +102,7 @@ class TransitionBranch
         }
 
         foreach ($this->actions as $actionDefinition) {
-            $this->transitionDefinition->source->machine->runAction($actionDefinition, $context, $eventBehavior);
+            $this->transitionDefinition->source->machine->runAction($actionDefinition, $context, $state, $eventBehavior);
         }
     }
 

--- a/src/Definition/TransitionBranch.php
+++ b/src/Definition/TransitionBranch.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tarfinlabs\EventMachine\Definition;
 
+use Tarfinlabs\EventMachine\Actor\State;
 use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Behavior\BehaviorType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
@@ -93,6 +94,7 @@ class TransitionBranch
      */
     public function runActions(
         ContextManager $context,
+        State $state,
         ?EventBehavior $eventBehavior = null
     ): void {
         if ($this->actions === null) {

--- a/src/Definition/TransitionDefinition.php
+++ b/src/Definition/TransitionDefinition.php
@@ -7,6 +7,7 @@ namespace Tarfinlabs\EventMachine\Definition;
 use Tarfinlabs\EventMachine\Actor\State;
 use Tarfinlabs\EventMachine\Behavior\BehaviorType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
+use Tarfinlabs\EventMachine\Exceptions\BehaviorNotFoundException;
 
 /**
  * Class TransitionDefinition.
@@ -119,10 +120,12 @@ class TransitionDefinition
      * to true, it is considered eligible. The method returns the first
      * eligible transition encountered or null if none is found.
      *
-     * @param  EventBehavior  $eventBehavior         The event used to evaluate guards.
+     * @param  EventBehavior  $eventBehavior The event used to evaluate guards.
      *
      * @return TransitionDefinition|null The first eligible transition or
      *         null if no eligible transition is found.
+     *
+     * @throws BehaviorNotFoundException
      */
     public function getFirstValidTransitionBranch(
         EventBehavior $eventBehavior,

--- a/src/Definition/TransitionDefinition.php
+++ b/src/Definition/TransitionDefinition.php
@@ -138,19 +138,20 @@ class TransitionDefinition
             }
 
             $guardsPassed = true;
-            foreach ($branch->guards as $guard) {
+            foreach ($branch->guards as $guardDefinition) {
                 $guardBehavior = $this->source->machine->getInvokableBehavior(
-                    behaviorDefinition: $guard,
+                    behaviorDefinition: $guardDefinition,
                     behaviorType: BehaviorType::Guard
                 );
 
-                $state->setInternalEventBehavior("guard.{$guard}.initial");
+                $state->setInternalEventBehavior("guard.{$guardDefinition}.initial");
                 if ($guardBehavior($state->context, $eventBehavior) !== true) {
-                    $state->setInternalEventBehavior("guard.{$guard}.fail");
+                    $state->setInternalEventBehavior("guard.{$guardDefinition}.fail");
                     $guardsPassed = false;
+
                     break;
                 }
-                $state->setInternalEventBehavior("guard.{$guard}.done");
+                $state->setInternalEventBehavior("guard.{$guardDefinition}.done");
             }
 
             if ($guardsPassed === true) {

--- a/src/Definition/TransitionDefinition.php
+++ b/src/Definition/TransitionDefinition.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tarfinlabs\EventMachine\Definition;
 
 use Tarfinlabs\EventMachine\Actor\State;
-use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Behavior\BehaviorType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
 
@@ -127,7 +126,6 @@ class TransitionDefinition
      */
     public function getFirstValidTransitionBranch(
         EventBehavior $eventBehavior,
-        ContextManager $context,
         State $state
     ): ?TransitionBranch {
         /* @var TransitionBranch $branch */
@@ -144,7 +142,7 @@ class TransitionDefinition
                 );
 
                 $state->setInternalEventBehavior("guard.{$guard}.initial");
-                if ($guardBehavior($context, $eventBehavior) !== true) {
+                if ($guardBehavior($state->context, $eventBehavior) !== true) {
                     $state->setInternalEventBehavior("guard.{$guard}.fail");
                     $guardsPassed = false;
                     break;

--- a/src/Definition/TransitionDefinition.php
+++ b/src/Definition/TransitionDefinition.php
@@ -144,14 +144,26 @@ class TransitionDefinition
                     behaviorType: BehaviorType::Guard
                 );
 
-                $state->setInternalEventBehavior("guard.{$guardDefinition}.initial");
+                $state->setInternalEventBehavior(
+                    type: InternalEvent::GUARD_INIT,
+                    placeholder: $guardDefinition
+                );
+
                 if ($guardBehavior($state->context, $eventBehavior) !== true) {
-                    $state->setInternalEventBehavior("guard.{$guardDefinition}.fail");
                     $guardsPassed = false;
+
+                    $state->setInternalEventBehavior(
+                        type: InternalEvent::GUARD_FAIL,
+                        placeholder: $guardDefinition
+                    );
 
                     break;
                 }
-                $state->setInternalEventBehavior("guard.{$guardDefinition}.done");
+
+                $state->setInternalEventBehavior(
+                    type: InternalEvent::GUARD_PASS,
+                    placeholder: $guardDefinition
+                );
             }
 
             if ($guardsPassed === true) {

--- a/src/Definition/TransitionDefinition.php
+++ b/src/Definition/TransitionDefinition.php
@@ -144,6 +144,7 @@ class TransitionDefinition
                     behaviorType: BehaviorType::Guard
                 );
 
+                // Record the internal guard init event.
                 $state->setInternalEventBehavior(
                     type: InternalEvent::GUARD_INIT,
                     placeholder: $guardDefinition
@@ -152,6 +153,7 @@ class TransitionDefinition
                 if ($guardBehavior($state->context, $eventBehavior) !== true) {
                     $guardsPassed = false;
 
+                    // Record the internal guard fail event.
                     $state->setInternalEventBehavior(
                         type: InternalEvent::GUARD_FAIL,
                         placeholder: $guardDefinition
@@ -160,6 +162,7 @@ class TransitionDefinition
                     break;
                 }
 
+                // Record the internal guard pass event.
                 $state->setInternalEventBehavior(
                     type: InternalEvent::GUARD_PASS,
                     placeholder: $guardDefinition

--- a/src/Definition/TransitionDefinition.php
+++ b/src/Definition/TransitionDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tarfinlabs\EventMachine\Definition;
 
+use Tarfinlabs\EventMachine\Actor\State;
 use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Behavior\BehaviorType;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
@@ -127,6 +128,7 @@ class TransitionDefinition
     public function getFirstValidTransitionBranch(
         EventBehavior $eventBehavior,
         ContextManager $context,
+        State $state
     ): ?TransitionBranch {
         /* @var TransitionBranch $branch */
         foreach ($this->branches as $branch) {
@@ -141,10 +143,13 @@ class TransitionDefinition
                     behaviorType: BehaviorType::Guard
                 );
 
+                $state->setInternalEventBehavior("guard.{$guard}.initial");
                 if ($guardBehavior($context, $eventBehavior) !== true) {
+                    $state->setInternalEventBehavior("guard.{$guard}.fail");
                     $guardsPassed = false;
                     break;
                 }
+                $state->setInternalEventBehavior("guard.{$guard}.done");
             }
 
             if ($guardsPassed === true) {

--- a/src/Models/MachineEvent.php
+++ b/src/Models/MachineEvent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tarfinlabs\EventMachine\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Tarfinlabs\EventMachine\Definition\SourceType;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Tarfinlabs\EventMachine\Database\Factories\MachineEventFactory;
@@ -21,6 +22,7 @@ class MachineEvent extends Model
         'sequence_number',
         'created_at',
         // Event Related Attributes
+        'source',
         'type',
         'payload',
         'version',
@@ -39,6 +41,7 @@ class MachineEvent extends Model
         'machine_id'      => 'string',
         'machine_value'   => 'json',
         'root_event_id'   => 'string',
+        'source'          => SourceType::class,
         'type'            => 'string',
         'payload'         => 'json',
         'version'         => 'integer',

--- a/tests/EventStoreTest.php
+++ b/tests/EventStoreTest.php
@@ -74,8 +74,8 @@ it('stores internal action events', function (): void {
         ->toEqual([
             'machine.init',
             'ADD',
-            'action.additionAction.initial',
-            'action.additionAction.done',
+            'machine.action.additionAction.init',
+            'machine.action.additionAction.done',
         ]);
 });
 

--- a/tests/EventStoreTest.php
+++ b/tests/EventStoreTest.php
@@ -118,7 +118,7 @@ it('stores internal guard events', function (): void {
         ->toEqual([
             'machine.init',
             'MUT',
-            'guard.isEvenGuard.initial',
-            'guard.isEvenGuard.fail',
+            'machine.guard.isEvenGuard.init',
+            'machine.guard.isEvenGuard.fail',
         ]);
 });

--- a/tests/EventStoreTest.php
+++ b/tests/EventStoreTest.php
@@ -6,7 +6,7 @@ use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Definition\EventDefinition;
 use Tarfinlabs\EventMachine\Definition\MachineDefinition;
 
-it('stores events', function (): void {
+it('stores external events', function (): void {
     $machine = MachineDefinition::define(config: [
         'id'      => 'traffic_light',
         'initial' => 'green',
@@ -36,7 +36,7 @@ it('stores events', function (): void {
     expect($newState->history)->toHaveCount(3);
 });
 
-it('stores action events', function (): void {
+it('stores internal action events', function (): void {
     $machine = MachineDefinition::define(
         config: [
             'initial' => 'active',
@@ -46,7 +46,9 @@ it('stores action events', function (): void {
             'states' => [
                 'active' => [
                     'on' => [
-                        'ADD' => ['actions' => 'additionAction'],
+                        'ADD' => [
+                            'actions' => 'additionAction',
+                        ],
                     ],
                 ],
             ],
@@ -69,10 +71,15 @@ it('stores action events', function (): void {
 
     expect($newState->history->pluck('type')->toArray())
         ->toHaveCount(4)
-        ->toEqual(['machine.initial', 'ADD', 'action.additionAction.initial', 'action.additionAction.done']);
+        ->toEqual([
+            'machine.initial',
+            'ADD',
+            'action.additionAction.initial',
+            'action.additionAction.done',
+        ]);
 });
 
-it('stores guard events', function (): void {
+it('stores internal guard events', function (): void {
     $machine = MachineDefinition::define(
         config: [
             'initial' => 'active',
@@ -108,5 +115,10 @@ it('stores guard events', function (): void {
 
     expect($newState->history->pluck('type')->toArray())
         ->toHaveCount(4)
-        ->toEqual(['machine.initial', 'MUT', 'guard.isEvenGuard.initial', 'guard.isEvenGuard.fail']);
+        ->toEqual([
+            'machine.initial',
+            'MUT',
+            'guard.isEvenGuard.initial',
+            'guard.isEvenGuard.fail',
+        ]);
 });

--- a/tests/EventStoreTest.php
+++ b/tests/EventStoreTest.php
@@ -72,7 +72,7 @@ it('stores internal action events', function (): void {
     expect($newState->history->pluck('type')->toArray())
         ->toHaveCount(4)
         ->toEqual([
-            'machine.initial',
+            'machine.init',
             'ADD',
             'action.additionAction.initial',
             'action.additionAction.done',
@@ -116,7 +116,7 @@ it('stores internal guard events', function (): void {
     expect($newState->history->pluck('type')->toArray())
         ->toHaveCount(4)
         ->toEqual([
-            'machine.initial',
+            'machine.init',
             'MUT',
             'guard.isEvenGuard.initial',
             'guard.isEvenGuard.fail',

--- a/tests/EventStoreTest.php
+++ b/tests/EventStoreTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Tarfinlabs\EventMachine\ContextManager;
+use Tarfinlabs\EventMachine\Definition\EventDefinition;
 use Tarfinlabs\EventMachine\Definition\MachineDefinition;
 
 it('stores events', function (): void {
@@ -31,5 +33,80 @@ it('stores events', function (): void {
         'type' => 'RED_TIMER',
     ]);
 
-    expect($newState->history)->toHaveCount(2);
+    expect($newState->history)->toHaveCount(3);
+});
+
+it('stores action events', function (): void {
+    $machine = MachineDefinition::define(
+        config: [
+            'initial' => 'active',
+            'context' => [
+                'count' => 0,
+            ],
+            'states' => [
+                'active' => [
+                    'on' => [
+                        'ADD' => ['actions' => 'additionAction'],
+                    ],
+                ],
+            ],
+        ],
+        behavior: [
+            'actions' => [
+                'additionAction' => function (ContextManager $context, EventDefinition $eventDefinition): void {
+                    $context->set('count', $context->get('count') + $eventDefinition->payload['value']);
+                },
+            ],
+        ]
+    );
+
+    $newState = $machine->transition(state: null, event: [
+        'type'    => 'ADD',
+        'payload' => [
+            'value' => 37,
+        ],
+    ]);
+
+    expect($newState->history->pluck('type')->toArray())
+        ->toHaveCount(4)
+        ->toEqual(['machine.initial', 'ADD', 'action.additionAction.initial', 'action.additionAction.done']);
+});
+
+it('stores guard events', function (): void {
+    $machine = MachineDefinition::define(
+        config: [
+            'initial' => 'active',
+            'context' => [
+                'count' => 1,
+            ],
+            'states' => [
+                'active' => [
+                    'on' => [
+                        'MUT' => [
+                            'guards'  => 'isEvenGuard',
+                            'actions' => 'multiplyByTwoAction',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        behavior: [
+            'actions' => [
+                'multiplyByTwoAction' => function (ContextManager $context): void {
+                    $context->set('count', $context->get('count') * 2);
+                },
+            ],
+            'guards' => [
+                'isEvenGuard' => function (ContextManager $context): bool {
+                    return $context->get('count') % 2 === 0;
+                },
+            ],
+        ],
+    );
+
+    $newState = $machine->transition(state: null, event: ['type' => 'MUT']);
+
+    expect($newState->history->pluck('type')->toArray())
+        ->toHaveCount(4)
+        ->toEqual(['machine.initial', 'MUT', 'guard.isEvenGuard.initial', 'guard.isEvenGuard.fail']);
 });


### PR DESCRIPTION
### Added
Added `source` column to `machine_events` table
Added `setInternalEventBehavior` method to `State`
Added `SourceType` enum
Added `source` column to `MachineEvent` model
Added `source` parameter to `EventBehavior`
Added `$state` parameter to `runExitActions` method in `StateDefinition`
Added `$state` parameter to `runActions` method in `TransitionBranch`
Added `$state` parameter to `runAction` method in `MachineDefinition`
Added `machine.initial` internal event
Added internal events for action
Added internal events for guard
The use of `setEventBehavior` in the `Transition` method has been relocated.
Removed `$context` param from `runEntryActions`, `runExitActions`, `runActions`, `runAction`, `getFirstValidTransitionBranch` methods