### PR TITLE
fix(MachineActor): Update `send()` method to assign the new state (WEB-3747)

### DIFF
--- a/src/Actor/MachineActor.php
+++ b/src/Actor/MachineActor.php
@@ -31,6 +31,8 @@ class MachineActor
 
     public function send(EventBehavior|array $event): State
     {
-        return $this->definition->transition($this->state, $event);
+        $this->state = $this->definition->transition($this->state, $event);
+
+        return $this->state;
     }
 }


### PR DESCRIPTION
This commit refactors the `send()` method in the `MachineActor` class. Instead of returning the new state directly from the `transition()` method, the new state is now assigned to the `state` property of the `MachineActor` class.

Previously, the `send()` method would return the new state as the result of the `transition()` method. This approach required the caller to capture the returned state and assign it manually. In this commit, the `send()` method is updated to assign the new state directly to the `state` property, eliminating the need for an additional assignment statement.