### PR TITLE
refactor(State): Record internal event types as base class names instead of FQCN (WEB-3761)

### DIFF
--- a/src/Actor/State.php
+++ b/src/Actor/State.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tarfinlabs\EventMachine\Actor;
 
+use Illuminate\Support\Str;
 use Symfony\Component\Uid\Ulid;
 use Illuminate\Support\Collection;
 use Tarfinlabs\EventMachine\ContextManager;
@@ -52,7 +53,7 @@ class State
     ): self {
         $type = ($placeholder === null)
             ? $type->value
-            : sprintf($type->value, $placeholder);
+            : sprintf($type->value, Str::of($placeholder)->classBasename()->camel());
 
         $eventDefinition = new EventDefinition(
             type: $type,


### PR DESCRIPTION
This commit refactors the event type placeholder formatting in the `State` class. Previously, the placeholder value was directly passed to the `sprintf` function, resulting in the full class name being used.

The change introduces the use of the `class_basename` function from the `Illuminate\Support\Str` class to extract the base name of the class from the placeholder value. This improves the readability and conciseness of the event type representation.