### PR TITLE
test: Add magic methods to ContextManager and tests (WEB-3802)

### DIFF
--- a/src/ContextManager.php
+++ b/src/ContextManager.php
@@ -135,4 +135,23 @@ class ContextManager extends Data
 
         return static::from($payload);
     }
+
+    // region Magic Setup
+
+    public function __set(string $name, $value): void
+    {
+        $this->set($name, $value);
+    }
+
+    public function __get(string $name): mixed
+    {
+        return $this->get($name);
+    }
+
+    public function __isset(string $name): bool
+    {
+        return $this->has($name);
+    }
+
+    // endregion
 }

--- a/tests/ContextManagerTest.php
+++ b/tests/ContextManagerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Tarfinlabs\EventMachine\ContextManager;
+use Tarfinlabs\EventMachine\Tests\Stubs\Machines\AbcMachine;
 use Tarfinlabs\EventMachine\Exceptions\MachineContextValidationException;
 use Tarfinlabs\EventMachine\Tests\Stubs\Machines\TrafficLights\TrafficLightsContext;
 use Tarfinlabs\EventMachine\Tests\Stubs\Machines\TrafficLights\TrafficLightsMachine;
@@ -101,3 +102,16 @@ test('TrafficLightsMachine transitions between states using EventMachine', funct
 test('TrafficLightsContext throws MachineContextValidationException for invalid data', function (): void {
     TrafficLightsContext::validateAndCreate(['count' => -1]);
 })->throws(MachineContextValidationException::class);
+
+it('has magic methods', function (): void {
+    $machine = AbcMachine::start();
+
+    $machine->state->context->set('key', 'value1');
+    expect($machine->state->context->key)->toBe('value1');
+
+    $machine->state->context->key = 'value2';
+    expect($machine->state->context->key)->toBe('value2');
+
+    expect(isset($machine->state->context->key))->toBe(true);
+    expect(isset($machine->state->context->not_existing_key))->toBe(false);
+});


### PR DESCRIPTION
Implemented magic methods __set, __get, and __isset in ContextManager class to streamline usage and improve readability of code. These methods enable direct property-like interaction with ContextManager objects. Additionally, test cases were written to confirm their correct functionality.