### PR TITLE
feat(ContextManager): Add type checking to `has()` method (WEB-3803)

### DIFF
--- a/src/ContextManager.php
+++ b/src/ContextManager.php
@@ -70,18 +70,35 @@ class ContextManager extends Data
     }
 
     /**
-     * Check if the context contains the given key.
+     * Determines if a key-value pair exists and optionally checks its type.
      *
-     *@param  string  $key The key to check for existence.
+     * This method checks if the context contains the given key and, if a type is
+     * specified, whether the value associated with that key is of the given type.
+     * If no type is specified, only existence is checked. If the key does not
+     * exist, or if the type does not match, the method returns false.
      *
-     *@return bool True if the key exists in the context, false otherwise.
+     * @param  string  $key  The key to check for existence.
+     * @param  string|null  $type  The type to check for the value. If null,
+     * only existence is checked.
+     *
+     * @return bool  True if the key exists and (if a type is specified)
+     * its value is of the given type. False otherwise.
      */
-    public function has(string $key): bool
+    public function has(string $key, string $type = null): bool
     {
-        return match (true) {
+        $hasKey = match (true) {
             get_class($this) === __CLASS__   => isset($this->data[$key]),
             is_subclass_of($this, __CLASS__) => property_exists($this, $key),
         };
+
+        if (!$hasKey || $type === null) {
+            return $hasKey;
+        }
+
+        $value     = $this->get($key);
+        $valueType = is_object($value) ? get_class($value) : gettype($value);
+
+        return $valueType === $type;
     }
 
     /**

--- a/tests/ContextManagerTest.php
+++ b/tests/ContextManagerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Tarfinlabs\EventMachine\ContextManager;
+use Tarfinlabs\EventMachine\Models\MachineEvent;
 use Tarfinlabs\EventMachine\Tests\Stubs\Machines\AbcMachine;
 use Tarfinlabs\EventMachine\Exceptions\MachineContextValidationException;
 use Tarfinlabs\EventMachine\Tests\Stubs\Machines\TrafficLights\TrafficLightsContext;
@@ -114,4 +115,20 @@ it('has magic methods', function (): void {
 
     expect(isset($machine->state->context->key))->toBe(true);
     expect(isset($machine->state->context->not_existing_key))->toBe(false);
+});
+
+test('abc', function (): void {
+    $machine = AbcMachine::start();
+
+    $machine->state->context->set('stringKey', 'stringValue');
+    expect($machine->state->context->has(key: 'stringKey', type: 'string'))->toBe(true);
+
+    $machine->state->context->set('intKey', 1);
+    expect($machine->state->context->has(key: 'intKey', type: 'integer'))->toBe(true);
+
+    $machine->state->context->set('arrayKey', []);
+    expect($machine->state->context->has(key: 'arrayKey', type: 'array'))->toBe(true);
+
+    $machine->state->context->set('objectKey', new MachineEvent());
+    expect($machine->state->context->has(key: 'objectKey', type: MachineEvent::class))->toBe(true);
 });


### PR DESCRIPTION
This commit enhances the `has()` method in the `ContextManager` class. Previously, this method only checked if a key exists in the context. Now, it can also check if the value associated with the key is of a specified type. If a type is not provided, the method only checks for the existence of the key.

Test cases in `ContextManagerTest` have also been added to verify this new functionality.