### PR TITLE
feat(TransitionBranch): Add description field (WEB-3816)

### DIFF
--- a/src/Definition/TransitionBranch.php
+++ b/src/Definition/TransitionBranch.php
@@ -26,6 +26,9 @@ class TransitionBranch
     /** The guards to be checked before this transition branch is taken. */
     public ?array $guards = null;
 
+    /** The description of the transition branch. */
+    public ?string $description = null;
+
     // endregion
 
     // region Constructor
@@ -55,6 +58,8 @@ class TransitionBranch
             $this->target = (!isset($this->transitionBranchConfig['target']) || $this->transitionBranchConfig['target'] === null
                     ? null
                     : $this->transitionDefinition->source->parent->stateDefinitions[$this->transitionBranchConfig['target']]);
+
+            $this->description = $this->transitionBranchConfig['description'] ?? null;
 
             $this->initializeConditions();
             $this->initializeActions();

--- a/tests/GuardedActionsTest.php
+++ b/tests/GuardedActionsTest.php
@@ -145,8 +145,9 @@ it('should transition through multiple if-else targets based on guards', functio
                     'on' => [
                         'TIMER' => [
                             [
-                                'target' => 'yellow',
-                                'guards' => 'isOneGuard',
+                                'target'      => 'yellow',
+                                'guards'      => 'isOneGuard',
+                                'description' => 'sample description',
                             ],
                             [
                                 'target' => 'red',
@@ -203,6 +204,9 @@ it('should transition through multiple if-else targets based on guards', functio
     expect($newState)
         ->toBeInstanceOf(State::class)
         ->and($newState->value)->toBe(['(machine).pedestrian']);
+
+    expect($machine->stateDefinitions['green']->transitionDefinitions['TIMER']->branches[0]->description)
+        ->toBe('sample description');
 });
 
 it('should prevent infinite loops when no guards evaluate to true for @always transitions', function (): void {


### PR DESCRIPTION
In the TransitionBranch class, a new description field has been added. This field is set based on the 'description' values in the transitionBranchConfig array. This change was made to provide a mechanism for having more descriptive data associated with transition branches. This newly added description field is also tested in GuardedActionsTest to ensure it works as expected.