### PR TITLE
feat: Add JSON serialization to MachineActor and test (WEB-3841)

### DIFF
--- a/src/Actor/MachineActor.php
+++ b/src/Actor/MachineActor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tarfinlabs\EventMachine\Actor;
 
+use JsonSerializable;
 use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Models\MachineEvent;
 use Tarfinlabs\EventMachine\Behavior\BehaviorType;
@@ -16,7 +17,7 @@ use Tarfinlabs\EventMachine\Exceptions\RestoringStateException;
 use Tarfinlabs\EventMachine\Exceptions\BehaviorNotFoundException;
 use Tarfinlabs\EventMachine\Exceptions\MachineValidationException;
 
-class MachineActor
+class MachineActor implements JsonSerializable
 {
     /** The current state of the machine actor. */
     public ?State $state = null;
@@ -181,4 +182,9 @@ class MachineActor
     }
 
     // endregion
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->state->history->first()->root_event_id;
+    }
 }

--- a/tests/MachineActorSerializationTest.php
+++ b/tests/MachineActorSerializationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Tarfinlabs\EventMachine\Actor\MachineActor;
+use Tarfinlabs\EventMachine\Tests\Stubs\Models\ModelA;
+
+test('a machine as a model attribute can serialize as root_event_id', function (): void {
+    $modelA = new ModelA();
+
+    expect($modelA->abc_mre)->toBeInstanceOf(MachineActor::class);
+    expect($modelA->traffic_mre)->toBeInstanceOf(MachineActor::class);
+
+    expect($modelA->toArray())->toBeArray();
+    expect($modelA->toJson())->toBeString();
+
+    $modelA->abc_mre->persist();
+    $modelA->traffic_mre->persist();
+    $modelA->save();
+
+    expect($modelA->toArray())->toBeArray();
+    expect($modelA->toJson())->toBeString();
+
+    $retrievedModelA = ModelA::findOrFail($modelA->id);
+
+    expect($retrievedModelA->toArray())->toBeArray();
+    expect($retrievedModelA->toJson())->toBeString();
+
+    expect($retrievedModelA->abc_mre)->toBeInstanceOf(MachineActor::class);
+    expect($retrievedModelA->traffic_mre)->toBeInstanceOf(MachineActor::class);
+});

--- a/tests/Stubs/Models/ModelA.php
+++ b/tests/Stubs/Models/ModelA.php
@@ -7,6 +7,7 @@ namespace Tarfinlabs\EventMachine\Tests\Stubs\Models;
 use Illuminate\Database\Eloquent\Model;
 use Tarfinlabs\EventMachine\Actor\MachineActor;
 use Tarfinlabs\EventMachine\Traits\HasMachines;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Tarfinlabs\EventMachine\Tests\Stubs\Machines\AbcMachine;
 use Tarfinlabs\EventMachine\Tests\Stubs\Machines\TrafficLights\TrafficLightsMachine;
 
@@ -20,6 +21,7 @@ use Tarfinlabs\EventMachine\Tests\Stubs\Machines\TrafficLights\TrafficLightsMach
 class ModelA extends Model
 {
     use HasMachines;
+    use HasFactory;
 
     protected $fillable = [
         'value',


### PR DESCRIPTION
The MachineActor class now implements JsonSerializable, enabling it to represent an object in serialized format for use in ModelA attribute serialization. Additionally, a new test file, MachineActorSerializationTest.php, is added to ensure the correct functionality of this new serialization ability. The ModelA class has also been updated to use HasFactory for testing convenience. This improves our testing capabilities and the flexibility in working with MachineActor instances.