### PR TITLE
refactor!(EventFactory): Do not validate event behavior after building an Event Behavior 

### DIFF
--- a/src/Factories/EventFactory.php
+++ b/src/Factories/EventFactory.php
@@ -9,11 +9,16 @@ use Tarfinlabs\EventMachine\Behavior\EventBehavior;
 
 abstract class EventFactory extends Factory
 {
+    /**
+     * Get a new model instance.
+     *
+     * @param  array<mixed>  $attributes
+     */
     public function newModel(array $attributes = []): EventBehavior
     {
         /** @var EventBehavior $model */
         $model = $this->modelName();
 
-        return $model::validateAndCreate($attributes);
+        return $model::from($attributes);
     }
 }


### PR DESCRIPTION
(WEB-3873) refactor!(EventFactory): Do not validate event behavior after building an Event Behavior 

The method call in EventFactory class has been changed from `validateAndCreate` to `from` in order to reflect the update in EventBehavior model's functionality. This change allows the usage of more flexible attribute sets for model instances.