### PR TITLE
Web 5120 form request siniflarinda bail ifadesinin kaldirilmasi ve stop on first failure ozelliginin kullanilmasi

### DIFF
--- a/src/Behavior/EventBehavior.php
+++ b/src/Behavior/EventBehavior.php
@@ -93,4 +93,14 @@ abstract class EventBehavior extends Data
     {
         return $this->payload['scenarioType'] ?? null;
     }
+
+    /**
+     * Indicates if the validator should stop on the first rule failure.
+     *
+     * @return bool Returns true by default.
+     */
+    public static function stopOnFirstFailure(): bool
+    {
+        return true;
+    }
 }

--- a/tests/EventValidationTest.php
+++ b/tests/EventValidationTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Tarfinlabs\EventMachine\ContextManager;
+use Illuminate\Validation\ValidationException;
 use Tarfinlabs\EventMachine\Definition\MachineDefinition;
 use Tarfinlabs\EventMachine\Tests\Stubs\Events\ValidatedEvent;
 
@@ -46,4 +47,44 @@ test('an event payload can be validated', function (): void {
     ]);
 
     expect($newState->context->data['value'])->toBe($randomMachineValue + $randomEventValue);
+});
+
+test('an event validator can stopping on the first validation failure', function (): void {
+    $machine = MachineDefinition::define(
+        config: [
+            'initial' => 'stateA',
+            'context' => [
+                'value' => 'test',
+            ],
+            'states' => [
+                'stateA' => [
+                    'on' => [
+                        ValidatedEvent::class => [
+                            'target'  => 'stateB',
+                            'actions' => 'updateContext',
+                        ],
+                    ],
+                ],
+                'stateB' => [],
+            ],
+        ],
+        behavior: [
+            'actions' => [
+                'foo' => function (ContextManager $context, ValidatedEvent $event) {
+                    return 'bar';
+                },
+            ],
+        ]
+    );
+
+    expect(function () use ($machine): void {
+        $machine->transition(event: [
+            'type'    => 'VALIDATED_EVENT',
+            'payload' => [],
+        ]);
+    })->toThrow(
+        exception: ValidationException::class,
+        exceptionMessage: 'Custom validation message for the attribute.'
+    );
+
 });

--- a/tests/Stubs/Events/ValidatedEvent.php
+++ b/tests/Stubs/Events/ValidatedEvent.php
@@ -13,6 +13,7 @@ class ValidatedEvent extends EventBehavior
     {
         return [
             'payload.attribute' => ['required', 'integer', 'min:1', 'max:10'],
+            'payload.value'     => ['nullable', 'integer', 'min:1', 'max:10'],
         ];
     }
 
@@ -20,6 +21,7 @@ class ValidatedEvent extends EventBehavior
     {
         return [
             'payload.attribute' => 'Custom validation message for the attribute.',
+            'payload.value'     => 'Custom validation message for the value.',
         ];
     }
 


### PR DESCRIPTION
This commit adds a new method `stopOnFirstFailure` to the `EventBehavior` class. This method indicates whether the validator should stop on the first rule failure. By default, it returns true. Developers can override this method in subclasses to change this behavior.