### PR TITLE
Wb 624 event machine convert context validation methods to static in invokable behavior class

### DIFF
--- a/src/Behavior/InvokableBehavior.php
+++ b/src/Behavior/InvokableBehavior.php
@@ -26,7 +26,7 @@ abstract class InvokableBehavior
     use Fakeable;
 
     /** @var array<string> An array containing the required context and the type of the context for the code to execute correctly. */
-    public array $requiredContext = [];
+    public static array $requiredContext = [];
 
     /** @var bool Write log in console */
     public bool $shouldLog = false;
@@ -67,16 +67,16 @@ abstract class InvokableBehavior
      * @return string|null The key of the first missing attribute, or null if all
      *                     required attributes are present.
      */
-    public function hasMissingContext(ContextManager $context): ?string
+    public static function hasMissingContext(ContextManager $context): ?string
     {
         // Check if the requiredContext property is an empty array
-        if (empty($this->requiredContext)) {
+        if (empty(static::$requiredContext)) {
             return null;
         }
 
         // Iterate through the required context attributes
         /* @var GuardBehavior $guardBehavior */
-        foreach ($this->requiredContext as $key => $type) {
+        foreach (static::$requiredContext as $key => $type) {
             // Check if the context manager has the required context attribute
             if (!$context->has($key, $type)) {
                 // Return the key of the missing context attribute
@@ -97,9 +97,9 @@ abstract class InvokableBehavior
      *
      * @param  ContextManager  $context  The context to be validated.
      */
-    public function validateRequiredContext(ContextManager $context): void
+    public static function validateRequiredContext(ContextManager $context): void
     {
-        $missingContext = $this->hasMissingContext($context);
+        $missingContext = static::hasMissingContext($context);
 
         if ($missingContext !== null) {
             throw MissingMachineContextException::build($missingContext);

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -2,12 +2,39 @@
 
 declare(strict_types=1);
 
+use Tarfinlabs\EventMachine\ContextManager;
+use Tarfinlabs\EventMachine\Behavior\InvokableBehavior;
 use Tarfinlabs\EventMachine\Definition\MachineDefinition;
 use Tarfinlabs\EventMachine\Tests\Stubs\Actions\IsOddAction;
 use Tarfinlabs\EventMachine\Tests\Stubs\Guards\IsValidatedOddGuard;
 use Tarfinlabs\EventMachine\Exceptions\MissingMachineContextException;
 
 test('context values can be required for guards and actions', function (): void {
+class TestBehaviorWithRequiredContext extends InvokableBehavior
+{
+    public static array $requiredContext = [
+        'user.id'          => 'integer',
+        'user.name'        => 'string',
+        'settings.enabled' => 'boolean',
+    ];
+
+    public function __invoke(): void {}
+}
+
+class TestBehaviorWithoutRequiredContext extends InvokableBehavior
+{
+    public function __invoke(): void {}
+}
+
+class TestBehaviorWithNestedRequiredContext extends InvokableBehavior
+{
+    public static array $requiredContext = [
+        'deeply.nested.value'   => 'string',
+        'another.nested.number' => 'integer',
+    ];
+
+    public function __invoke(): void {}
+}
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -106,6 +106,18 @@ test('hasMissingContext handles deeply nested context paths', function (): void 
 
     expect($behavior->hasMissingContext($incompleteContext))->toBe('another.nested.number');
 });
+
+test('hasMissingContext returns first missing key for multiple missing fields', function (): void {
+    $behavior = new TestBehaviorWithRequiredContext();
+    $context  = new ContextManager([
+        'settings' => [
+            'enabled' => true,
+        ],
+        // user.id and user.name both missing
+    ]);
+
+    expect($behavior->hasMissingContext($context))->toBe('user.id');
+});
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -59,6 +59,21 @@ test('hasMissingContext returns null when all required context is present', func
 
     expect($behavior->hasMissingContext($context))->toBeNull();
 });
+
+test('hasMissingContext returns the first missing key path when context is missing', function (): void {
+    $behavior = new TestBehaviorWithRequiredContext();
+    $context  = new ContextManager([
+        'user' => [
+            'id' => 1,
+            // name is missing
+        ],
+        'settings' => [
+            'enabled' => true,
+        ],
+    ]);
+
+    expect($behavior->hasMissingContext($context))->toBe('user.name');
+});
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -133,6 +133,22 @@ test('hasMissingContext checks type constraints', function (): void {
 
     expect($behavior->hasMissingContext($context))->toBe('user.id');
 });
+
+test('validateRequiredContext throws exception with correct missing key message', function (): void {
+    $behavior = new TestBehaviorWithRequiredContext();
+    $context  = new ContextManager([
+        'user' => [
+            'id' => 1,
+            // name is missing
+        ],
+        'settings' => [
+            'enabled' => true,
+        ],
+    ]);
+
+    expect(fn () => $behavior->validateRequiredContext($context))
+        ->toThrow(MissingMachineContextException::class, '`user.name` is missing in context.');
+});
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -149,6 +149,22 @@ test('validateRequiredContext throws exception with correct missing key message'
     expect(fn () => $behavior->validateRequiredContext($context))
         ->toThrow(MissingMachineContextException::class, '`user.name` is missing in context.');
 });
+
+test('validateRequiredContext passes when all context is present', function (): void {
+    $behavior = new TestBehaviorWithRequiredContext();
+    $context  = new ContextManager([
+        'user' => [
+            'id'   => 1,
+            'name' => 'John',
+        ],
+        'settings' => [
+            'enabled' => true,
+        ],
+    ]);
+
+    expect($behavior->validateRequiredContext($context))->toBeNull();
+    expect(fn () => $behavior->validateRequiredContext($context))->not->toThrow(MissingMachineContextException::class);
+});
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -118,6 +118,21 @@ test('hasMissingContext returns first missing key for multiple missing fields', 
 
     expect($behavior->hasMissingContext($context))->toBe('user.id');
 });
+
+test('hasMissingContext checks type constraints', function (): void {
+    $behavior = new TestBehaviorWithRequiredContext();
+    $context  = new ContextManager([
+        'user' => [
+            'id'   => 'not_an_integer', // Wrong type
+            'name' => 'John',
+        ],
+        'settings' => [
+            'enabled' => true,
+        ],
+    ]);
+
+    expect($behavior->hasMissingContext($context))->toBe('user.id');
+});
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -36,17 +36,17 @@ class TestBehaviorWithNestedRequiredContext extends InvokableBehavior
 }
 
 test('hasMissingContext returns null when no required context is defined', function (): void {
-    $behavior = new TestBehaviorWithoutRequiredContext();
-    $context  = new ContextManager([
+    $context = new ContextManager([
         'some' => 'value',
     ]);
 
-    expect($behavior->hasMissingContext($context))->toBeNull();
+    $result = TestBehaviorWithoutRequiredContext::hasMissingContext($context);
+
+    expect($result)->toBeNull();
 });
 
 test('hasMissingContext returns null when all required context is present', function (): void {
-    $behavior = new TestBehaviorWithRequiredContext();
-    $context  = new ContextManager([
+    $context = new ContextManager([
         'user' => [
             'id'   => 1,
             'name' => 'John',
@@ -56,12 +56,13 @@ test('hasMissingContext returns null when all required context is present', func
         ],
     ]);
 
-    expect($behavior->hasMissingContext($context))->toBeNull();
+    $result = TestBehaviorWithRequiredContext::hasMissingContext($context);
+
+    expect($result)->toBeNull();
 });
 
 test('hasMissingContext returns the first missing key path when context is missing', function (): void {
-    $behavior = new TestBehaviorWithRequiredContext();
-    $context  = new ContextManager([
+    $context = new ContextManager([
         'user' => [
             'id' => 1,
             // name is missing
@@ -71,12 +72,12 @@ test('hasMissingContext returns the first missing key path when context is missi
         ],
     ]);
 
-    expect($behavior->hasMissingContext($context))->toBe('user.name');
+    $result = TestBehaviorWithRequiredContext::hasMissingContext($context);
+
+    expect($result)->toBe('user.name');
 });
 
 test('hasMissingContext handles deeply nested context paths', function (): void {
-    $behavior = new TestBehaviorWithNestedRequiredContext();
-
     // All required context present
     $completeContext = new ContextManager([
         'deeply' => [
@@ -91,7 +92,9 @@ test('hasMissingContext handles deeply nested context paths', function (): void 
         ],
     ]);
 
-    expect($behavior->hasMissingContext($completeContext))->toBeNull();
+    $result = TestBehaviorWithNestedRequiredContext::hasMissingContext($completeContext);
+
+    expect($result)->toBeNull();
 
     // Missing nested context
     $incompleteContext = new ContextManager([
@@ -103,24 +106,26 @@ test('hasMissingContext handles deeply nested context paths', function (): void 
         // another.nested.number is missing
     ]);
 
-    expect($behavior->hasMissingContext($incompleteContext))->toBe('another.nested.number');
+    $result = TestBehaviorWithNestedRequiredContext::hasMissingContext($incompleteContext);
+
+    expect($result)->toBe('another.nested.number');
 });
 
 test('hasMissingContext returns first missing key for multiple missing fields', function (): void {
-    $behavior = new TestBehaviorWithRequiredContext();
-    $context  = new ContextManager([
+    $context = new ContextManager([
         'settings' => [
             'enabled' => true,
         ],
         // user.id and user.name both missing
     ]);
 
-    expect($behavior->hasMissingContext($context))->toBe('user.id');
+    $result = TestBehaviorWithRequiredContext::hasMissingContext($context);
+
+    expect($result)->toBe('user.id');
 });
 
 test('hasMissingContext checks type constraints', function (): void {
-    $behavior = new TestBehaviorWithRequiredContext();
-    $context  = new ContextManager([
+    $context = new ContextManager([
         'user' => [
             'id'   => 'not_an_integer', // Wrong type
             'name' => 'John',
@@ -130,12 +135,13 @@ test('hasMissingContext checks type constraints', function (): void {
         ],
     ]);
 
-    expect($behavior->hasMissingContext($context))->toBe('user.id');
+    $result = TestBehaviorWithRequiredContext::hasMissingContext($context);
+
+    expect($result)->toBe('user.id');
 });
 
 test('validateRequiredContext throws exception with correct missing key message', function (): void {
-    $behavior = new TestBehaviorWithRequiredContext();
-    $context  = new ContextManager([
+    $context = new ContextManager([
         'user' => [
             'id' => 1,
             // name is missing
@@ -145,13 +151,12 @@ test('validateRequiredContext throws exception with correct missing key message'
         ],
     ]);
 
-    expect(fn () => $behavior->validateRequiredContext($context))
+    expect(fn () => TestBehaviorWithRequiredContext::validateRequiredContext($context))
         ->toThrow(MissingMachineContextException::class, '`user.name` is missing in context.');
 });
 
 test('validateRequiredContext passes when all context is present', function (): void {
-    $behavior = new TestBehaviorWithRequiredContext();
-    $context  = new ContextManager([
+    $context = new ContextManager([
         'user' => [
             'id'   => 1,
             'name' => 'John',
@@ -161,15 +166,14 @@ test('validateRequiredContext passes when all context is present', function (): 
         ],
     ]);
 
-    expect($behavior->validateRequiredContext($context))->toBeNull();
-    expect(fn () => $behavior->validateRequiredContext($context))->not->toThrow(MissingMachineContextException::class);
+    expect(TestBehaviorWithRequiredContext::validateRequiredContext($context))->toBeNull();
+    expect(fn () => TestBehaviorWithRequiredContext::validateRequiredContext($context))->not->toThrow(MissingMachineContextException::class);
 });
 
 test('validateRequiredContext throws exception for empty context when requirements exist', function (): void {
-    $behavior = new TestBehaviorWithRequiredContext();
-    $context  = new ContextManager([]);
+    $context = new ContextManager([]);
 
-    expect(fn () => $behavior->validateRequiredContext($context))
+    expect(fn () => TestBehaviorWithRequiredContext::validateRequiredContext($context))
         ->toThrow(MissingMachineContextException::class, '`user.id` is missing in context.');
 });
 

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -9,7 +9,6 @@ use Tarfinlabs\EventMachine\Tests\Stubs\Actions\IsOddAction;
 use Tarfinlabs\EventMachine\Tests\Stubs\Guards\IsValidatedOddGuard;
 use Tarfinlabs\EventMachine\Exceptions\MissingMachineContextException;
 
-test('context values can be required for guards and actions', function (): void {
 class TestBehaviorWithRequiredContext extends InvokableBehavior
 {
     public static array $requiredContext = [
@@ -165,6 +164,16 @@ test('validateRequiredContext passes when all context is present', function (): 
     expect($behavior->validateRequiredContext($context))->toBeNull();
     expect(fn () => $behavior->validateRequiredContext($context))->not->toThrow(MissingMachineContextException::class);
 });
+
+test('validateRequiredContext throws exception for empty context when requirements exist', function (): void {
+    $behavior = new TestBehaviorWithRequiredContext();
+    $context  = new ContextManager([]);
+
+    expect(fn () => $behavior->validateRequiredContext($context))
+        ->toThrow(MissingMachineContextException::class, '`user.id` is missing in context.');
+});
+
+test('context values can be required for guards and actions inside machine', function (): void {
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -35,6 +35,15 @@ class TestBehaviorWithNestedRequiredContext extends InvokableBehavior
 
     public function __invoke(): void {}
 }
+
+test('hasMissingContext returns null when no required context is defined', function (): void {
+    $behavior = new TestBehaviorWithoutRequiredContext();
+    $context  = new ContextManager([
+        'some' => 'value',
+    ]);
+
+    expect($behavior->hasMissingContext($context))->toBeNull();
+});
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -74,6 +74,38 @@ test('hasMissingContext returns the first missing key path when context is missi
 
     expect($behavior->hasMissingContext($context))->toBe('user.name');
 });
+
+test('hasMissingContext handles deeply nested context paths', function (): void {
+    $behavior = new TestBehaviorWithNestedRequiredContext();
+
+    // All required context present
+    $completeContext = new ContextManager([
+        'deeply' => [
+            'nested' => [
+                'value' => 'test',
+            ],
+        ],
+        'another' => [
+            'nested' => [
+                'number' => 42,
+            ],
+        ],
+    ]);
+
+    expect($behavior->hasMissingContext($completeContext))->toBeNull();
+
+    // Missing nested context
+    $incompleteContext = new ContextManager([
+        'deeply' => [
+            'nested' => [
+                'value' => 'test',
+            ],
+        ],
+        // another.nested.number is missing
+    ]);
+
+    expect($behavior->hasMissingContext($incompleteContext))->toBe('another.nested.number');
+});
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/RequiredContextTest.php
+++ b/tests/RequiredContextTest.php
@@ -44,6 +44,21 @@ test('hasMissingContext returns null when no required context is defined', funct
 
     expect($behavior->hasMissingContext($context))->toBeNull();
 });
+
+test('hasMissingContext returns null when all required context is present', function (): void {
+    $behavior = new TestBehaviorWithRequiredContext();
+    $context  = new ContextManager([
+        'user' => [
+            'id'   => 1,
+            'name' => 'John',
+        ],
+        'settings' => [
+            'enabled' => true,
+        ],
+    ]);
+
+    expect($behavior->hasMissingContext($context))->toBeNull();
+});
     $machineDefinition = MachineDefinition::define(config: [
         'context' => [
             'counts' => [

--- a/tests/Stubs/Actions/IsOddAction.php
+++ b/tests/Stubs/Actions/IsOddAction.php
@@ -9,7 +9,7 @@ use Tarfinlabs\EventMachine\Behavior\ActionBehavior;
 
 class IsOddAction extends ActionBehavior
 {
-    public array $requiredContext = [
+    public static array $requiredContext = [
         'counts.oddCount' => 'integer',
     ];
 

--- a/tests/Stubs/Guards/IsOddGuard.php
+++ b/tests/Stubs/Guards/IsOddGuard.php
@@ -9,7 +9,7 @@ use Tarfinlabs\EventMachine\Tests\Stubs\Machines\TrafficLights\TrafficLightsCont
 
 class IsOddGuard extends GuardBehavior
 {
-    public array $requiredContext = [
+    public static array $requiredContext = [
         'counts.oddCount' => 'integer',
     ];
 

--- a/tests/Stubs/Guards/IsValidatedOddGuard.php
+++ b/tests/Stubs/Guards/IsValidatedOddGuard.php
@@ -9,7 +9,7 @@ use Tarfinlabs\EventMachine\Tests\Stubs\Machines\TrafficLights\TrafficLightsCont
 
 class IsValidatedOddGuard extends ValidationGuardBehavior
 {
-    public array $requiredContext = [
+    public static array $requiredContext = [
         'counts.oddCount' => 'integer',
     ];
     public ?string $errorMessage = 'Count is not odd';


### PR DESCRIPTION
# Make InvokableBehavior context validation methods static

## Background
The `InvokableBehavior` class provides context validation functionality through `hasMissingContext()` and `validateRequiredContext()` methods. These methods were instance-based but did not rely on any instance state since they only validate required context types against provided context values.

## Changes
- Made `$requiredContext` property static in `InvokableBehavior` class and its subclasses
- Converted `hasMissingContext()` and `validateRequiredContext()` to static methods
- Updated test helper classes to use static `$requiredContext`
- Refactored tests to use static method calls instead of creating instances
- Added comprehensive test cases for all context validation scenarios

## Why
- More logical API: Since validation is class-based (defined by `$requiredContext` in each behavior class) rather than instance-based, static methods make more sense
- Better performance: No need to instantiate behaviors just for context validation
- Clearer intention: Static property and methods better communicate that context requirements are class-level concerns
- Easier testing: Can validate contexts without creating behavior instances

## Backwards Compatibility
This is a breaking change as it modifies method signatures and property visibility. Any code that relies on instance-based context validation will need to be updated to use static calls.