### PR TITLE
Wb 707 event machine enable testing of inline behaviors in machine definitions

### DIFF
--- a/src/Actor/Machine.php
+++ b/src/Actor/Machine.php
@@ -16,6 +16,7 @@ use Tarfinlabs\EventMachine\Enums\BehaviorType;
 use Tarfinlabs\EventMachine\Models\MachineEvent;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
 use Illuminate\Contracts\Database\Eloquent\Castable;
+use Tarfinlabs\EventMachine\Traits\ResolvesBehaviors;
 use Tarfinlabs\EventMachine\Enums\StateDefinitionType;
 use Tarfinlabs\EventMachine\Definition\EventDefinition;
 use Tarfinlabs\EventMachine\Definition\StateDefinition;
@@ -28,6 +29,8 @@ use Tarfinlabs\EventMachine\Exceptions\MachineDefinitionNotFoundException;
 
 class Machine implements Castable, JsonSerializable, Stringable
 {
+    use ResolvesBehaviors;
+
     // region Fields
 
     /** The machine definition that this machine is based on */

--- a/src/Traits/ResolvesBehaviors.php
+++ b/src/Traits/ResolvesBehaviors.php
@@ -45,4 +45,12 @@ trait ResolvesBehaviors
     {
         return static::getBehavior(BehaviorType::Guard->value.'.'.$name);
     }
+
+    /**
+     * Get an action behavior.
+     */
+    public static function getAction(string $name): ?callable
+    {
+        return static::getBehavior(BehaviorType::Action->value.'.'.$name);
+    }
 }

--- a/src/Traits/ResolvesBehaviors.php
+++ b/src/Traits/ResolvesBehaviors.php
@@ -37,4 +37,12 @@ trait ResolvesBehaviors
     {
         return static::getBehavior(BehaviorType::Calculator->value.'.'.$name);
     }
+
+    /**
+     * Get a guard behavior.
+     */
+    public static function getGuard(string $name): ?callable
+    {
+        return static::getBehavior(BehaviorType::Guard->value.'.'.$name);
+    }
 }

--- a/src/Traits/ResolvesBehaviors.php
+++ b/src/Traits/ResolvesBehaviors.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tarfinlabs\EventMachine\Traits;
+
+use Tarfinlabs\EventMachine\Enums\BehaviorType;
+use Tarfinlabs\EventMachine\Behavior\EventBehavior;
+use Tarfinlabs\EventMachine\Exceptions\BehaviorNotFoundException;
+
+trait ResolvesBehaviors
+{
+}

--- a/src/Traits/ResolvesBehaviors.php
+++ b/src/Traits/ResolvesBehaviors.php
@@ -53,4 +53,12 @@ trait ResolvesBehaviors
     {
         return static::getBehavior(BehaviorType::Action->value.'.'.$name);
     }
+
+    /**
+     * Get an event behavior.
+     */
+    public static function getEvent(string $name): ?EventBehavior
+    {
+        return static::getBehavior(BehaviorType::Event->value.'.'.$name);
+    }
 }

--- a/src/Traits/ResolvesBehaviors.php
+++ b/src/Traits/ResolvesBehaviors.php
@@ -29,4 +29,12 @@ trait ResolvesBehaviors
 
         return $behaviors[$type][$name];
     }
+
+    /**
+     * Get a calculator behavior.
+     */
+    public static function getCalculator(string $name): ?callable
+    {
+        return static::getBehavior(BehaviorType::Calculator->value.'.'.$name);
+    }
 }

--- a/src/Traits/ResolvesBehaviors.php
+++ b/src/Traits/ResolvesBehaviors.php
@@ -10,4 +10,23 @@ use Tarfinlabs\EventMachine\Exceptions\BehaviorNotFoundException;
 
 trait ResolvesBehaviors
 {
+    /**
+     * Get a specific behavior by its path.
+     *
+     * @param  string  $path  Behavior path (e.g. 'guards.createOrderAction')
+     *
+     * @throws BehaviorNotFoundException
+     */
+    public static function getBehavior(string $path): callable|EventBehavior
+    {
+        $behaviors = static::definition()?->behavior ?? [];
+
+        [$type, $name] = explode('.', $path);
+
+        if (!isset($behaviors[$type][$name])) {
+            throw BehaviorNotFoundException::build($path);
+        }
+
+        return $behaviors[$type][$name];
+    }
 }

--- a/tests/ResolveInlineBehaviorTest.php
+++ b/tests/ResolveInlineBehaviorTest.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/ResolveInlineBehaviorTest.php
+++ b/tests/ResolveInlineBehaviorTest.php
@@ -53,3 +53,18 @@ test('it can get an event behavior', function (): void {
     expect($eventBehavior)->toBeInstanceOf(EventBehavior::class)
         ->and($eventBehavior::getType())->toBe('ORDER_CREATED');
 });
+
+test('it throws exception when behavior not found', function (): void {
+    expect(fn () => OrderMachine::getCalculator('nonExistentCalculator'))
+        ->toThrow(BehaviorNotFoundException::class, 'Behavior of type `calculators.nonExistentCalculator` not found.');
+
+    expect(fn () => OrderMachine::getGuard('nonExistentGuard'))
+        ->toThrow(BehaviorNotFoundException::class, 'Behavior of type `guards.nonExistentGuard` not found.');
+
+    expect(fn () => OrderMachine::getAction('nonExistentAction'))
+        ->toThrow(BehaviorNotFoundException::class, 'Behavior of type `actions.nonExistentAction` not found.');
+
+    expect(fn () => OrderMachine::getEvent('nonExistentEvent'))
+        ->toThrow(BehaviorNotFoundException::class, 'Behavior of type `events.nonExistentEvent` not found.');
+});
+

--- a/tests/ResolveInlineBehaviorTest.php
+++ b/tests/ResolveInlineBehaviorTest.php
@@ -1,3 +1,21 @@
 <?php
 
 declare(strict_types=1);
+
+use Tarfinlabs\EventMachine\ContextManager;
+use Tarfinlabs\EventMachine\Behavior\EventBehavior;
+use Tarfinlabs\EventMachine\Tests\Stubs\Machines\OrderMachine;
+use Tarfinlabs\EventMachine\Exceptions\BehaviorNotFoundException;
+
+test('it can get a calculator behavior', function (): void {
+    // 1. Arrange
+    $calculator = OrderMachine::getCalculator('calculateOrderTotal');
+    $context    = new ContextManager(['items_count' => 5]);
+
+    // 2. Act
+    $calculator($context);
+
+    // 3. Assert
+    expect($calculator)->toBeCallable();
+    expect($context->get('items_count'))->toBe(50);
+});

--- a/tests/ResolveInlineBehaviorTest.php
+++ b/tests/ResolveInlineBehaviorTest.php
@@ -68,3 +68,8 @@ test('it throws exception when behavior not found', function (): void {
         ->toThrow(BehaviorNotFoundException::class, 'Behavior of type `events.nonExistentEvent` not found.');
 });
 
+test('it throws exception when behavior type not found', function (): void {
+    // Act & Assert
+    expect(fn () => OrderMachine::getBehavior('invalidType.someBehavior'))
+        ->toThrow(BehaviorNotFoundException::class, 'Behavior of type `invalidType.someBehavior` not found.');
+});

--- a/tests/ResolveInlineBehaviorTest.php
+++ b/tests/ResolveInlineBehaviorTest.php
@@ -31,3 +31,16 @@ test('it can get a guard behavior', function (): void {
         ->and($guard($validContext))->toBeTrue()
         ->and($guard($invalidContext))->toBeFalse();
 });
+
+test('it can get an action behavior', function (): void {
+    // 1. Arrange
+    $action  = OrderMachine::getAction('createOrder');
+    $context = new ContextManager();
+
+    // 2. Act
+    $action($context);
+
+    // 3. Assert
+    expect($action)->toBeCallable()
+        ->and($context->get('order_created'))->toBeTrue();
+});

--- a/tests/ResolveInlineBehaviorTest.php
+++ b/tests/ResolveInlineBehaviorTest.php
@@ -44,3 +44,12 @@ test('it can get an action behavior', function (): void {
     expect($action)->toBeCallable()
         ->and($context->get('order_created'))->toBeTrue();
 });
+
+test('it can get an event behavior', function (): void {
+    // 1. Act
+    $eventBehavior = OrderMachine::getEvent('orderCreated');
+
+    // 3. Assert
+    expect($eventBehavior)->toBeInstanceOf(EventBehavior::class)
+        ->and($eventBehavior::getType())->toBe('ORDER_CREATED');
+});

--- a/tests/ResolveInlineBehaviorTest.php
+++ b/tests/ResolveInlineBehaviorTest.php
@@ -19,3 +19,15 @@ test('it can get a calculator behavior', function (): void {
     expect($calculator)->toBeCallable();
     expect($context->get('items_count'))->toBe(50);
 });
+
+test('it can get a guard behavior', function (): void {
+    // 1. Arrange
+    $guard          = OrderMachine::getGuard('validateOrder');
+    $validContext   = new ContextManager(['items_count' => 5]);
+    $invalidContext = new ContextManager(['items_count' => 0]);
+
+    // 2. Act & 3. Assert
+    expect($guard)->toBeCallable()
+        ->and($guard($validContext))->toBeTrue()
+        ->and($guard($invalidContext))->toBeFalse();
+});

--- a/tests/Stubs/Machines/OrderMachine.php
+++ b/tests/Stubs/Machines/OrderMachine.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tarfinlabs\EventMachine\Tests\Stubs\Machines;
+
+use Tarfinlabs\EventMachine\Actor\Machine;
+use Tarfinlabs\EventMachine\ContextManager;
+use Tarfinlabs\EventMachine\Behavior\EventBehavior;
+use Tarfinlabs\EventMachine\Definition\MachineDefinition;
+
+class OrderMachine extends Machine
+{
+    public static function definition(): MachineDefinition
+    {
+        return MachineDefinition::define(
+            config: [
+                'initial' => 'idle',
+                'context' => [
+                    'items_count' => 0,
+                ],
+                'states' => [
+                    'idle' => [
+                        'on' => [
+                            'CREATE_ORDER' => [
+                                'target'      => 'processing',
+                                'calculators' => 'calculateOrderTotal',
+                                'guards'      => 'validateOrder',
+                                'actions'     => 'createOrder',
+                            ],
+                        ],
+                    ],
+                    'processing' => [],
+                ],
+            ],
+            behavior: [
+                'calculators' => [
+                    'calculateOrderTotal' => function (ContextManager $context): void {
+                        $context->items_count *= 10;
+                    },
+                ],
+                'guards' => [
+                    'validateOrder' => function (ContextManager $context): bool {
+                        return $context->get('items_count') > 0;
+                    },
+                ],
+                'actions' => [
+                    'createOrder' => function (ContextManager $context): void {
+                        $context->set('order_created', true);
+                    },
+                ],
+                'events' => [
+                    'orderCreated' => new class() extends EventBehavior {
+                        public static function getType(): string
+                        {
+                            return 'ORDER_CREATED';
+                        }
+                    },
+                ],
+            ],
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces the `ResolvesBehaviors` trait that enables direct testing of inline behaviors defined within machine definitions. This enhancement significantly improves testability of state machine components by allowing developers to access and test behaviors without instantiating the entire machine.

### Features
- Direct access to calculator behaviors via `getCalculator()`
- Direct access to guard behaviors via `getGuard()`
- Direct access to action behaviors via `getAction()`
- Direct access to event behaviors via `getEvent()`
- Type-safe behavior resolution with proper return types
- Clear error handling with `BehaviorNotFoundException`

### Example Usage
```php
// Testing a calculator behavior
$calculator = OrderMachine::getCalculator('calculateTotal');
$context = new ContextManager(['count' => 5]);
$calculator($context);
expect($context->get('total'))->toBe(50);

// Testing a guard behavior
$guard = OrderMachine::getGuard('validateOrder');
$context = new ContextManager(['items' => 3]);
expect($guard($context))->toBeTrue();

// Testing an action behavior
$action = OrderMachine::getAction('createOrder');
$context = new ContextManager();
$action($context);
expect($context->get('order_created'))->toBeTrue();