### PR TITLE
Validation for State Machine Configuration Structure

### DIFF
--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -403,9 +403,9 @@ class MachineDefinition
      * @param  string  $behaviorDefinition  The behavior definition to look up.
      * @param  BehaviorType  $behaviorType  The type of the behavior (e.g., guard or action).
      *
-     * @return callable|null The invokable behavior instance or callable, or null if not found.
+     * @return callable|\Tarfinlabs\EventMachine\Behavior\InvokableBehavior|null The invokable behavior instance or callable, or null if not found.
      */
-    public function getInvokableBehavior(string $behaviorDefinition, BehaviorType $behaviorType): ?callable
+    public function getInvokableBehavior(string $behaviorDefinition, BehaviorType $behaviorType): null|callable|InvokableBehavior
     {
         // If the guard definition is an invokable GuardBehavior, create a new instance.
         if (is_subclass_of($behaviorDefinition, InvokableBehavior::class)) {

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -724,7 +724,7 @@ class MachineDefinition
         );
 
         if ($actionBehavior instanceof InvokableBehavior) {
-            $actionBehavior->validateRequiredContext($state->context);
+            $actionBehavior::validateRequiredContext($state->context);
         }
 
         // Get the number of events in the queue before the action is executed.

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -633,7 +633,7 @@ class MachineDefinition
 
         // Get scenario state if exists
         $newState = $this->getScenarioStateIfAvailable(state: $newState, eventBehavior: $eventBehavior);
-        if ($targetStateDefinition !== null && $targetStateDefinition?->id !== $newState->currentStateDefinition->id) {
+        if ($targetStateDefinition !== null && $targetStateDefinition->id !== $newState->currentStateDefinition->id) {
             $targetStateDefinition = $newState->currentStateDefinition;
         }
 

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -9,6 +9,7 @@ use Tarfinlabs\EventMachine\Actor\State;
 use Tarfinlabs\EventMachine\ContextManager;
 use Tarfinlabs\EventMachine\Enums\BehaviorType;
 use Tarfinlabs\EventMachine\Enums\InternalEvent;
+use Tarfinlabs\EventMachine\StateConfigValidator;
 use Tarfinlabs\EventMachine\Behavior\EventBehavior;
 use Tarfinlabs\EventMachine\Enums\TransitionProperty;
 use Tarfinlabs\EventMachine\Enums\StateDefinitionType;
@@ -84,6 +85,8 @@ class MachineDefinition
         public ?array $scenarios,
         public string $delimiter = self::STATE_DELIMITER,
     ) {
+        StateConfigValidator::validate($config, $this->id);
+
         $this->scenariosEnabled = isset($this->config['scenarios_enabled']) && $this->config['scenarios_enabled'] === true;
 
         $this->shouldPersist = $this->config['should_persist'] ?? $this->shouldPersist;

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -224,7 +224,7 @@ class MachineDefinition
             currentStateDefinition: $this->initialStateDefinition,
         );
 
-        $initialState                 = $this->getScenarioStateIfAvailable(state: $initialState, eventBehavior: $eventBehavior ?? null);
+        $initialState                 = $this->getScenarioStateIfAvailable(state: $initialState, eventBehavior: $event ?? null);
         $this->initialStateDefinition = $initialState->currentStateDefinition;
 
         // Record the internal machine init event.

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -298,7 +298,7 @@ class MachineDefinition
         }
 
         $scenarioStateKey = str_replace($this->id, $this->id.$this->delimiter.$state->context->get('scenarioType'), $state->currentStateDefinition->id);
-        if ($state->context->has('scenarioType') && isset($this->idMap[$scenarioStateKey])) {
+        if (isset($this->idMap[$scenarioStateKey]) && $state->context->has('scenarioType')) {
             return $state->setCurrentStateDefinition(stateDefinition: $this->idMap[$scenarioStateKey]);
         }
 

--- a/src/Definition/MachineDefinition.php
+++ b/src/Definition/MachineDefinition.php
@@ -85,7 +85,7 @@ class MachineDefinition
         public ?array $scenarios,
         public string $delimiter = self::STATE_DELIMITER,
     ) {
-        StateConfigValidator::validate($config, $this->id);
+        StateConfigValidator::validate($config);
 
         $this->scenariosEnabled = isset($this->config['scenarios_enabled']) && $this->config['scenarios_enabled'] === true;
 

--- a/src/Definition/TransitionDefinition.php
+++ b/src/Definition/TransitionDefinition.php
@@ -167,7 +167,7 @@ class TransitionDefinition
                 $shouldLog = $guardBehavior?->shouldLog ?? false;
 
                 if ($guardBehavior instanceof GuardBehavior) {
-                    $guardBehavior->validateRequiredContext($state->context);
+                    $guardBehavior::validateRequiredContext($state->context);
                 }
 
                 // Inject guard behavior parameters

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -215,4 +215,22 @@ class StateConfigValidator
             }
         }
     }
+
+    /**
+     * Validates transitions configuration.
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function validateTransitionsConfig(mixed $transitionsConfig, string $path): void
+    {
+        if (!is_array($transitionsConfig)) {
+            throw new InvalidArgumentException(
+                message: "State '{$path}' has invalid 'on' definition. 'on' must be an array of transitions."
+            );
+        }
+
+        foreach ($transitionsConfig as $eventName => $transition) {
+            self::validateTransition(transition: $transition, path: $path, eventName: $eventName);
+        }
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -195,4 +195,24 @@ class StateConfigValidator
             );
         }
     }
+
+    /**
+     * Validates state entry and exit actions.
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function validateStateActions(array $stateConfig, string $path): void
+    {
+        foreach (['entry', 'exit'] as $actionType) {
+            if (isset($stateConfig[$actionType])) {
+                $actions = $stateConfig[$actionType];
+                if (!is_string($actions) && !is_array($actions)) {
+                    throw new InvalidArgumentException(
+                        message: "State '{$path}' has invalid {$actionType} actions configuration. ".
+                        'Actions must be an array or string.'
+                    );
+                }
+            }
+        }
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tarfinlabs\EventMachine;
 
+use InvalidArgumentException;
+
 class StateConfigValidator
 {
     /** Allowed keys at different levels of the machine configuration */
@@ -25,4 +27,26 @@ class StateConfigValidator
     private const VALID_STATE_TYPES = [
         'atomic', 'compound', 'final',
     ];
+
+    /**
+     * Normalizes the given value into an array or returns null.
+     *
+     * @throws InvalidArgumentException If the value is neither string, array, nor null.
+     */
+    private static function normalizeArrayOrString(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            return [$value];
+        }
+
+        if (is_array($value)) {
+            return $value;
+        }
+
+        throw new InvalidArgumentException('Value must be string, array or null');
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -233,4 +233,40 @@ class StateConfigValidator
             self::validateTransition(transition: $transition, path: $path, eventName: $eventName);
         }
     }
+
+    /**
+     * Validates a single transition configuration.
+     */
+    private static function validateTransition(
+        mixed $transition,
+        string $path,
+        string $eventName
+    ): void {
+        if ($transition === null) {
+            return;
+        }
+
+        if (is_string($transition)) {
+            return;
+        }
+
+        if (!is_array($transition)) {
+            throw new InvalidArgumentException(
+                message: "State '{$path}' has invalid transition for event '{$eventName}'. ".
+                'Transition must be a string (target state) or an array (transition config).'
+            );
+        }
+
+        // If it's an array of conditions (guarded transitions)
+        if (array_is_list($transition)) {
+            self::validateGuardedTransitions($transition, $path, $eventName);
+            foreach ($transition as &$condition) {
+                self::validateTransitionConfig(transitionConfig: $condition, path: $path, eventName: $eventName);
+            }
+
+            return;
+        }
+
+        self::validateTransitionConfig(transitionConfig: $transition, path: $path, eventName: $eventName);
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -335,8 +335,8 @@ class StateConfigValidator
         foreach ($conditions as $index => $condition) {
             if (!is_array($condition)) {
                 throw new InvalidArgumentException(
-                    message: "State '{$path}' has invalid condition at index {$index} for event '{$eventName}'. ".
-                    'Each condition must be an array.'
+                    message: "State '{$path}' has invalid condition in transition for event '{$eventName}'. ".
+                    'Each condition must be an array with target/guards/actions.'
                 );
             }
 

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -67,7 +67,7 @@ class StateConfigValidator
         // Validate states if they exist
         if (isset($config['states'])) {
             if (!is_array($config['states'])) {
-                throw new InvalidArgumentException('States configuration must be an array.');
+                throw new InvalidArgumentException(message: 'States configuration must be an array.');
             }
 
             foreach ($config['states'] as $stateName => $stateConfig) {
@@ -77,7 +77,7 @@ class StateConfigValidator
 
         // Validate root level transitions if they exist
         if (isset($config['on'])) {
-            self::validateTransitionsConfig($config['on'], 'root');
+            self::validateTransitionsConfig(transitionsConfig: $config['on'], path: 'root');
         }
     }
 
@@ -95,8 +95,8 @@ class StateConfigValidator
 
         if (!empty($invalidRootKeys)) {
             throw new InvalidArgumentException(
-                'Invalid root level configuration keys: '.implode(', ', $invalidRootKeys).
-                '. Allowed keys are: '.implode(', ', self::ALLOWED_ROOT_KEYS)
+                message: 'Invalid root level configuration keys: '.implode(separator: ', ', array: $invalidRootKeys).
+                '. Allowed keys are: '.implode(separator: ', ', array: self::ALLOWED_ROOT_KEYS)
             );
         }
     }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -175,4 +175,24 @@ class StateConfigValidator
             );
         }
     }
+
+    /**
+     * Validates final state constraints.
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function validateFinalState(array $stateConfig, string $path): void
+    {
+        if (isset($stateConfig['on'])) {
+            throw new InvalidArgumentException(
+                message: "Final state '{$path}' cannot have transitions"
+            );
+        }
+
+        if (isset($stateConfig['states'])) {
+            throw new InvalidArgumentException(
+                message: "Final state '{$path}' cannot have child states"
+            );
+        }
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -347,17 +347,12 @@ class StateConfigValidator
                 );
             }
 
-            // Check if this is a default condition (no guards)
-            $isDefaultCondition = !isset($condition['guards']);
-
-            if ($isDefaultCondition) {
-                // If this is not the last condition
-                if ($index !== count($conditions) - 1) {
-                    throw new InvalidArgumentException(
-                        message: "State '{$path}' has invalid conditions order for event '{$eventName}'. ".
-                        'Default condition (no guards) must be the last condition.'
-                    );
-                }
+            // If this is not the last condition
+            if (!isset($condition['guards']) && $index !== count($conditions) - 1) {
+                throw new InvalidArgumentException(
+                    message: "State '{$path}' has invalid conditions order for event '{$eventName}'. ".
+                    'Default condition (no guards) must be the last condition.'
+                );
             }
         }
     }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -269,4 +269,26 @@ class StateConfigValidator
 
         self::validateTransitionConfig(transitionConfig: $transition, path: $path, eventName: $eventName);
     }
+
+    /**
+     * Validates the configuration of a single transition.
+     */
+    private static function validateTransitionConfig(
+        array &$transitionConfig,
+        string $path,
+        string $eventName
+    ): void {
+        // Validate allowed keys
+        $invalidKeys = array_diff(array_keys($transitionConfig), self::ALLOWED_TRANSITION_KEYS);
+        if (!empty($invalidKeys)) {
+            throw new InvalidArgumentException(
+                message: "State '{$path}' has invalid keys in transition config for event '{$eventName}': ".
+                    implode(separator: ', ', array: $invalidKeys).
+                    '. Allowed keys are: '.implode(separator: ', ', array: self::ALLOWED_TRANSITION_KEYS)
+            );
+        }
+
+        // Normalize and validate behaviors
+        self::validateTransitionBehaviors(transitionConfig: $transitionConfig, path: $path, eventName: $eventName);
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -16,7 +16,7 @@ class StateConfigValidator
     ];
 
     private const ALLOWED_STATE_KEYS = [
-        'on', 'states', 'initial', 'type', 'meta', 'entry', 'exit', 'description',
+        'id', 'on', 'states', 'initial', 'type', 'meta', 'entry', 'exit', 'description', 'result',
     ];
 
     private const ALLOWED_TRANSITION_KEYS = [

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -309,7 +309,7 @@ class StateConfigValidator
         foreach ($behaviors as $behavior => $label) {
             if (isset($transitionConfig[$behavior])) {
                 try {
-                    $transitionConfig[$behavior] = self::normalizeArrayOrString($transitionConfig[$behavior]);
+                    $transitionConfig[$behavior] = self::normalizeArrayOrString(value: $transitionConfig[$behavior]);
                 } catch (InvalidArgumentException) {
                     throw new InvalidArgumentException(
                         message: "State '{$path}' has invalid {$behavior} configuration for event '{$eventName}'. ".

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -160,4 +160,19 @@ class StateConfigValidator
             self::validateTransitionsConfig(transitionsConfig: $stateConfig['on'], path: $path);
         }
     }
+
+    /**
+     * Validates state type configuration.
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function validateStateType(array $stateConfig, string $path): void
+    {
+        if (!in_array($stateConfig['type'], haystack: self::VALID_STATE_TYPES, strict: true)) {
+            throw new InvalidArgumentException(
+                message: "State '{$path}' has invalid type: {$stateConfig['type']}. ".
+                'Allowed types are: '.implode(separator: ', ', array: self::VALID_STATE_TYPES)
+            );
+        }
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tarfinlabs\EventMachine;
+
+class StateConfigValidator
+{
+    /** Allowed keys at different levels of the machine configuration */
+    private const ALLOWED_ROOT_KEYS = [
+        'id', 'version', 'initial', 'context', 'states', 'on', 'type',
+        'meta', 'entry', 'exit', 'description', 'scenarios_enabled',
+        'should_persist', 'delimiter',
+    ];
+
+    private const ALLOWED_STATE_KEYS = [
+        'on', 'states', 'initial', 'type', 'meta', 'entry', 'exit', 'description',
+    ];
+
+    private const ALLOWED_TRANSITION_KEYS = [
+        'target', 'guards', 'actions', 'description', 'calculators',
+    ];
+
+    /** Valid state types matching StateDefinitionType enum */
+    private const VALID_STATE_TYPES = [
+        'atomic', 'compound', 'final',
+    ];
+}

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -49,4 +49,35 @@ class StateConfigValidator
 
         throw new InvalidArgumentException('Value must be string, array or null');
     }
+
+    /**
+     * Validates the machine configuration structure.
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function validate(?array $config): void
+    {
+        if ($config === null) {
+            return;
+        }
+
+        // Validate root level configuration
+        self::validateRootConfig($config);
+
+        // Validate states if they exist
+        if (isset($config['states'])) {
+            if (!is_array($config['states'])) {
+                throw new InvalidArgumentException('States configuration must be an array.');
+            }
+
+            foreach ($config['states'] as $stateName => $stateConfig) {
+                self::validateStateConfig($stateConfig, $stateName);
+            }
+        }
+
+        // Validate root level transitions if they exist
+        if (isset($config['on'])) {
+            self::validateTransitionsConfig($config['on'], 'root');
+        }
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -315,4 +315,46 @@ class StateConfigValidator
             }
         }
     }
+
+    /**
+     * Validates guarded transitions with multiple conditions.
+     */
+    private static function validateGuardedTransitions(array $conditions, string $path, string $eventName): void
+    {
+        if (empty($conditions)) {
+            throw new InvalidArgumentException(
+                message: "State '{$path}' has empty conditions array for event '{$eventName}'. ".
+                'Guarded transitions must have at least one condition.'
+            );
+        }
+
+        foreach ($conditions as $index => $condition) {
+            if (!is_array($condition)) {
+                throw new InvalidArgumentException(
+                    message: "State '{$path}' has invalid condition at index {$index} for event '{$eventName}'. ".
+                    'Each condition must be an array.'
+                );
+            }
+
+            if (!isset($condition['target'])) {
+                throw new InvalidArgumentException(
+                    message: "State '{$path}' has invalid condition at index {$index} for event '{$eventName}'. ".
+                    'Each condition must have a target.'
+                );
+            }
+
+            // Check if this is a default condition (no guards)
+            $isDefaultCondition = !isset($condition['guards']);
+
+            if ($isDefaultCondition) {
+                // If this is not the last condition
+                if ($index !== count($conditions) - 1) {
+                    throw new InvalidArgumentException(
+                        message: "State '{$path}' has invalid conditions order for event '{$eventName}'. ".
+                        'Default condition (no guards) must be the last condition.'
+                    );
+                }
+            }
+        }
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -80,4 +80,24 @@ class StateConfigValidator
             self::validateTransitionsConfig($config['on'], 'root');
         }
     }
+
+    /**
+     * Validates root level configuration.
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function validateRootConfig(array $config): void
+    {
+        $invalidRootKeys = array_diff(
+            array_keys($config),
+            self::ALLOWED_ROOT_KEYS
+        );
+
+        if (!empty($invalidRootKeys)) {
+            throw new InvalidArgumentException(
+                'Invalid root level configuration keys: '.implode(', ', $invalidRootKeys).
+                '. Allowed keys are: '.implode(', ', self::ALLOWED_ROOT_KEYS)
+            );
+        }
+    }
 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -300,16 +300,20 @@ class StateConfigValidator
         string $path,
         string $eventName
     ): void {
-        $behaviors = ['guards', 'actions', 'calculators'];
+        $behaviors = [
+            'guards'      => 'Guards',
+            'actions'     => 'Actions',
+            'calculators' => 'Calculators',
+        ];
 
-        foreach ($behaviors as $behavior) {
+        foreach ($behaviors as $behavior => $label) {
             if (isset($transitionConfig[$behavior])) {
                 try {
-                    $transitionConfig[$behavior] = self::normalizeArrayOrString(value: $transitionConfig[$behavior]);
+                    $transitionConfig[$behavior] = self::normalizeArrayOrString($transitionConfig[$behavior]);
                 } catch (InvalidArgumentException) {
                     throw new InvalidArgumentException(
                         message: "State '{$path}' has invalid {$behavior} configuration for event '{$eventName}'. ".
-                        "{$behavior} must be an array or string."
+                        "{$label} must be an array or string."
                     );
                 }
             }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -208,7 +208,7 @@ class StateConfigValidator
                 $actions = $stateConfig[$actionType];
                 if (!is_string($actions) && !is_array($actions)) {
                     throw new InvalidArgumentException(
-                        message: "State '{$path}' has invalid {$actionType} actions configuration. ".
+                        message: "State '{$path}' has invalid entry/exit actions configuration. ".
                         'Actions must be an array or string.'
                     );
                 }

--- a/src/StateConfigValidator.php
+++ b/src/StateConfigValidator.php
@@ -291,4 +291,28 @@ class StateConfigValidator
         // Normalize and validate behaviors
         self::validateTransitionBehaviors(transitionConfig: $transitionConfig, path: $path, eventName: $eventName);
     }
+
+    /**
+     * Validates and normalizes transition behaviors (guards, actions, calculators).
+     */
+    private static function validateTransitionBehaviors(
+        array &$transitionConfig,
+        string $path,
+        string $eventName
+    ): void {
+        $behaviors = ['guards', 'actions', 'calculators'];
+
+        foreach ($behaviors as $behavior) {
+            if (isset($transitionConfig[$behavior])) {
+                try {
+                    $transitionConfig[$behavior] = self::normalizeArrayOrString(value: $transitionConfig[$behavior]);
+                } catch (InvalidArgumentException) {
+                    throw new InvalidArgumentException(
+                        message: "State '{$path}' has invalid {$behavior} configuration for event '{$eventName}'. ".
+                        "{$behavior} must be an array or string."
+                    );
+                }
+            }
+        }
+    }
 }

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -117,6 +117,25 @@ test('validates condition arrays in transitions', function (): void {
         exceptionMessage: "State 'state_a' has invalid condition in transition for event 'EVENT'. Each condition must be an array with target/guards/actions."
     );
 });
+test('validates actions configuration in transitions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        'target'  => 'state_b',
+                        'actions' => true, // Actions should be an array or string
+                    ],
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid actions configuration for event 'EVENT'. Actions must be an array or string."
+    );
+});
 test('validates allowed keys in transition config', function (): void {
     expect(fn () => MachineDefinition::define([
         'id'      => 'machine',

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -236,3 +236,18 @@ test('normalizes string behaviors to arrays', function (): void {
     ]))->not->toThrow(exception: InvalidArgumentException::class);
 });
 
+test('validates empty guarded transitions array', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'     => 'machine',
+        'states' => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [], // Empty conditions array
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has empty conditions array for event 'EVENT'. Guarded transitions must have at least one condition."
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -251,3 +251,27 @@ test('validates empty guarded transitions array', function (): void {
         exceptionMessage: "State 'state_a' has empty conditions array for event 'EVENT'. Guarded transitions must have at least one condition."
     );
 });
+
+test('validates default condition must be last in guarded transitions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'     => 'machine',
+        'states' => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        [
+                            'target' => 'state_b', // Default condition (no guards)
+                        ],
+                        [
+                            'target' => 'state_c',
+                            'guards' => 'someGuard',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid conditions order for event 'EVENT'. Default condition (no guards) must be the last condition."
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -131,3 +131,21 @@ test('validates state type values', function (): void {
         exceptionMessage: "State 'state_a' has invalid type: invalid_type. Allowed types are: atomic, compound, final"
     );
 });
+
+test('validates final states have no transitions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'type' => 'final',
+                'on'   => [
+                    'EVENT' => 'state_b',
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "Final state 'state_a' cannot have transitions"
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -17,3 +17,19 @@ test('validates root level configuration keys', function (): void {
         exceptionMessage: 'Invalid root level configuration keys: invalid_key, another_invalid. Allowed keys are: id, version, initial, context, states, on, type, meta, entry, exit, description, scenarios_enabled, should_persist, delimiter'
     );
 });
+
+test('accepts valid root level configuration', function (): void {
+    // HINT: This test should contain all possible root level configuration keys
+    expect(fn () => MachineDefinition::define([
+        'id'                => 'machine',
+        'version'           => '1.0.0',
+        'initial'           => 'state_a',
+        'context'           => ['some' => 'data'],
+        'scenarios_enabled' => true,
+        'should_persist'    => true,
+        'delimiter'         => '.',
+        'states'            => [
+            'state_a' => [],
+        ],
+    ]))->not->toThrow(exception: InvalidArgumentException::class);
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -136,6 +136,27 @@ test('validates actions configuration in transitions', function (): void {
         exceptionMessage: "State 'state_a' has invalid actions configuration for event 'EVENT'. Actions must be an array or string."
     );
 });
+
+test('validates calculators configuration in transitions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        'target'      => 'state_b',
+                        'calculators' => 123, // Calculators should be an array or string
+                    ],
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid calculators configuration for event 'EVENT'. Calculators must be an array or string."
+    );
+});
+
 test('validates allowed keys in transition config', function (): void {
     expect(fn () => MachineDefinition::define([
         'id'      => 'machine',

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -229,6 +229,22 @@ test('validates final states have no child states', function (): void {
     );
 });
 
+test('validates entry and exit actions are arrays or strings', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'entry' => true, // Should be an array or a string
+                'exit'  => 123, // Should be an array or a string
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid entry/exit actions configuration. Actions must be an array or string."
+    );
+});
+
 test('accepts valid state configuration with all possible features', function (): void {
     expect(fn () => MachineDefinition::define([
         'id'      => 'machine',

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -97,6 +97,26 @@ test('validates transition target is either string or array', function (): void 
         exceptionMessage: "State 'state_a' has invalid transition for event 'EVENT'. Transition must be a string (target state) or an array (transition config)."
     );
 });
+
+test('validates condition arrays in transitions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        'not_an_array', // Invalid condition - should be an array
+                        ['target' => 'state_b'],
+                    ],
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid condition in transition for event 'EVENT'. Each condition must be an array with target/guards/actions."
+    );
+});
 test('validates allowed keys in transition config', function (): void {
     expect(fn () => MachineDefinition::define([
         'id'      => 'machine',

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -116,3 +116,18 @@ test('validates allowed keys in transition config', function (): void {
         exceptionMessage: "State 'state_a' has invalid keys in transition config for event 'EVENT': invalid_key, another_invalid. Allowed keys are: target, guards, actions, description, calculators"
     );
 });
+
+test('validates state type values', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'type' => 'invalid_type', // Type should be 'atomic', 'compound', or 'final'
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid type: invalid_type. Allowed types are: atomic, compound, final"
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -47,3 +47,20 @@ test('accepts machine with root level transitions', function (): void {
         ],
     ]))->not->toThrow(InvalidArgumentException::class);
 });
+
+test('transitions must be defined under the on key', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'check',
+        'states'  => [
+            'check' => [
+                '@always' => [ // Transition defined directly under state
+                    'target' => 'next',
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'check' has transitions defined directly. All transitions including '@always' must be defined under the 'on' key."
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -117,6 +117,27 @@ test('validates condition arrays in transitions', function (): void {
         exceptionMessage: "State 'state_a' has invalid condition in transition for event 'EVENT'. Each condition must be an array with target/guards/actions."
     );
 });
+
+test('validates guards configuration in transitions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        'target' => 'state_b',
+                        'guards' => true, // Guards should be an array or a string
+                    ],
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        InvalidArgumentException::class,
+        "State 'state_a' has invalid guards configuration for event 'EVENT'. Guards must be an array or string."
+    );
+});
+
 test('validates actions configuration in transitions', function (): void {
     expect(fn () => MachineDefinition::define([
         'id'      => 'machine',

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -33,3 +33,17 @@ test('accepts valid root level configuration', function (): void {
         ],
     ]))->not->toThrow(exception: InvalidArgumentException::class);
 });
+
+test('accepts machine with root level transitions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'on'      => [
+            'GLOBAL_EVENT' => 'state_b',
+        ],
+        'states' => [
+            'state_a' => [],
+            'state_b' => [],
+        ],
+    ]))->not->toThrow(InvalidArgumentException::class);
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -295,3 +295,30 @@ test('validates target is required in guarded transitions', function (): void {
         exceptionMessage: "State 'state_a' has invalid condition at index 0 for event 'EVENT'. Each condition must have a target."
     );
 });
+
+test('accepts valid guarded transitions with multiple conditions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'     => 'machine',
+        'states' => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        [
+                            'target'      => 'state_b',
+                            'guards'      => ['guard1', 'guard2'],
+                            'actions'     => 'action1',
+                            'calculators' => ['calc1', 'calc2'],
+                        ],
+                        [
+                            'target' => 'state_c',
+                            'guards' => 'guard3',
+                        ],
+                        [
+                            'target' => 'state_d', // Default condition
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]))->not->toThrow(exception: InvalidArgumentException::class);
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use InvalidArgumentException;
+use Tarfinlabs\EventMachine\Definition\MachineDefinition;
+
+test('validates root level configuration keys', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'              => 'machine',
+        'invalid_key'     => 'value',
+        'another_invalid' => 'value',
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: 'Invalid root level configuration keys: invalid_key, another_invalid. Allowed keys are: id, version, initial, context, states, on, type, meta, entry, exit, description, scenarios_enabled, should_persist, delimiter'
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -64,3 +64,18 @@ test('transitions must be defined under the on key', function (): void {
         exceptionMessage: "State 'check' has transitions defined directly. All transitions including '@always' must be defined under the 'on' key."
     );
 });
+
+test('validates on property is an array', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'on' => 'invalid_string', // 'on' should be an array
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid 'on' definition. 'on' must be an array of transitions."
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -96,3 +96,23 @@ test('validates transition target is either string or array', function (): void 
         exceptionMessage: "State 'state_a' has invalid transition for event 'EVENT'. Transition must be a string (target state) or an array (transition config)."
     );
 });
+test('validates allowed keys in transition config', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        'target'          => 'state_b',
+                        'invalid_key'     => 'value',
+                        'another_invalid' => 'value',
+                    ],
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid keys in transition config for event 'EVENT': invalid_key, another_invalid. Allowed keys are: target, guards, actions, description, calculators"
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -275,3 +275,23 @@ test('validates default condition must be last in guarded transitions', function
         exceptionMessage: "State 'state_a' has invalid conditions order for event 'EVENT'. Default condition (no guards) must be the last condition."
     );
 });
+
+test('validates target is required in guarded transitions', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'     => 'machine',
+        'states' => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        [
+                            'guards' => 'someGuard', // Missing target
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid condition at index 0 for event 'EVENT'. Each condition must have a target."
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -79,3 +79,20 @@ test('validates on property is an array', function (): void {
         exceptionMessage: "State 'state_a' has invalid 'on' definition. 'on' must be an array of transitions."
     );
 });
+
+test('validates transition target is either string or array', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => true, // Invalid transition definition
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "State 'state_a' has invalid transition for event 'EVENT'. Transition must be a string (target state) or an array (transition config)."
+    );
+});

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -217,3 +217,22 @@ test('accepts valid state configuration with all possible features', function ()
         ],
     ]))->not->toThrow(exception: InvalidArgumentException::class);
 });
+
+test('normalizes string behaviors to arrays', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'     => 'machine',
+        'states' => [
+            'state_a' => [
+                'on' => [
+                    'EVENT' => [
+                        'target'      => 'state_b',
+                        'guards'      => 'singleGuard',
+                        'actions'     => 'singleAction',
+                        'calculators' => 'singleCalculator',
+                    ],
+                ],
+            ],
+        ],
+    ]))->not->toThrow(exception: InvalidArgumentException::class);
+});
+

--- a/tests/StateConfigValidatorTest.php
+++ b/tests/StateConfigValidatorTest.php
@@ -149,3 +149,22 @@ test('validates final states have no transitions', function (): void {
         exceptionMessage: "Final state 'state_a' cannot have transitions"
     );
 });
+
+test('validates final states have no child states', function (): void {
+    expect(fn () => MachineDefinition::define([
+        'id'      => 'machine',
+        'initial' => 'state_a',
+        'states'  => [
+            'state_a' => [
+                'type'   => 'final',
+                'states' => [
+                    'child' => [],
+                ],
+            ],
+        ],
+    ]))->toThrow(
+        exception: InvalidArgumentException::class,
+        exceptionMessage: "Final state 'state_a' cannot have child states"
+    );
+});
+

--- a/tests/StateDefinitionTypeTest.php
+++ b/tests/StateDefinitionTypeTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Support\Carbon;
 use Tarfinlabs\EventMachine\Actor\Machine;
-use Tarfinlabs\EventMachine\ContextManager;
-use Tarfinlabs\EventMachine\Behavior\EventBehavior;
 use Tarfinlabs\EventMachine\Enums\StateDefinitionType;
 use Tarfinlabs\EventMachine\Definition\MachineDefinition;
 use Tarfinlabs\EventMachine\Tests\Stubs\Results\GreenResult;
@@ -72,7 +70,7 @@ test('a machine can have outputs on final states', function (string $eventType):
                 ],
                 'yellow' => [
                     'type'   => 'final',
-                    'result' => function (ContextManager $context, EventBehavior $event): Carbon {
+                    'result' => function (): Carbon {
                         return now();
                     },
                 ],

--- a/tests/StateDefinitionTypeTest.php
+++ b/tests/StateDefinitionTypeTest.php
@@ -9,7 +9,6 @@ use Tarfinlabs\EventMachine\Behavior\EventBehavior;
 use Tarfinlabs\EventMachine\Enums\StateDefinitionType;
 use Tarfinlabs\EventMachine\Definition\MachineDefinition;
 use Tarfinlabs\EventMachine\Tests\Stubs\Results\GreenResult;
-use Tarfinlabs\EventMachine\Exceptions\InvalidFinalStateDefinitionException;
 
 test('a state definition can be atomic', function (): void {
     $machine = MachineDefinition::define(config: [
@@ -95,44 +94,6 @@ test('a machine can have outputs on final states', function (string $eventType):
     '@yellow',
     '@green',
 ]);
-
-test('a final state definition can not have child states', function (): void {
-    MachineDefinition::define(config: [
-        'initial' => 'yellow',
-        'states'  => [
-            'yellow' => [
-                'type'   => 'final',
-                'states' => [
-                    'a' => [],
-                    'b' => [],
-                ],
-            ],
-        ],
-    ]);
-})->throws(
-    exception: InvalidFinalStateDefinitionException::class,
-    exceptionMessage: 'The final state `machine.yellow` should not have child states. Please revise your state machine definitions to ensure that final states are correctly configured without child states.'
-);
-
-test('a final state definition can not have transitions', function (): void {
-    MachineDefinition::define(config: [
-        'initial' => 'yellow',
-        'states'  => [
-            'yellow' => [
-                'type' => 'final',
-                'on'   => [
-                    'EVENT' => [
-                        'target' => 'red',
-                    ],
-                ],
-            ],
-            'red' => [],
-        ],
-    ]);
-})->throws(
-    exception: InvalidFinalStateDefinitionException::class,
-    exceptionMessage: 'The final state `machine.yellow` should not have transitions. Check your state machine configuration to ensure events are not dispatched when in a final state.'
-);
 
 test('an initial state of type final triggers machine finish event', function (): void {
     $machine = Machine::create(definition: [


### PR DESCRIPTION
Introduces strict validation for state machine configurations through the new `StateConfigValidator` class, ensuring consistency and early error detection.

## Key Changes

- Add validation for root-level machine configuration
- Validate state properties and transitions
- Enforce proper structure for guards and actions
- Improve error messages for configuration issues

Example usage in machine definitions:

```php
MachineDefinition::define([
    'id' => 'order',
    'initial' => 'pending',
    'states' => [
        'pending' => [
            'on' => {
                'APPROVE' => [
                    'target' => 'approved',
                    'guards' => 'isValid'  // Now validated
                ]
            }
        ]
    ]
]);
```

The validator checks for:
- Valid keys at each configuration level
- Proper structure for transitions and guards
- Correct state type definitions
- Valid entry/exit actions format

Any configuration issues now throw `InvalidArgumentException` with clear error messages, helping developers catch problems early in development rather than at runtime. For example:

```php
// Invalid configuration - will throw exception
MachineDefinition::define([
    'states' => [
        'pending' => [
            'invalid_key' => 'value',  // Invalid state key
            'on' => [
                '@always' => 'next'    // Must be under 'on'
            ]
        ]
    ]
]);
```

This enhancement improves developer experience by providing immediate feedback on configuration errors and enforcing consistent machine definitions across your application.