### PR TITLE
Config validator command

### DIFF
--- a/src/Commands/GenerateUmlCommand.php
+++ b/src/Commands/GenerateUmlCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tarfinlabs\EventMachine\Console\Commands;
+namespace Tarfinlabs\EventMachine\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;

--- a/src/Commands/MachineConfigValidatorCommand.php
+++ b/src/Commands/MachineConfigValidatorCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tarfinlabs\EventMachine\Commands;
+
+use Illuminate\Console\Command;
+
+class MachineConfigValidatorCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'machine:validate {machine: The Machine Class}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $machinePath = $this->argument('machine');
+    }
+}

--- a/src/Commands/MachineConfigValidatorCommand.php
+++ b/src/Commands/MachineConfigValidatorCommand.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Tarfinlabs\EventMachine\Commands;
 
+use Throwable;
+use ReflectionClass;
+use InvalidArgumentException;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Finder\SplFileInfo;
+use Tarfinlabs\EventMachine\Actor\Machine;
+use Tarfinlabs\EventMachine\StateConfigValidator;
 
 class MachineConfigValidatorCommand extends Command
 {
@@ -13,20 +20,211 @@ class MachineConfigValidatorCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'machine:validate {machine: The Machine Class}';
+    protected $signature = 'machine:validate {machine?*} {--all : Validate all machines in the project}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Validate machine configuration for potential issues';
 
     /**
      * Execute the console command.
      */
     public function handle(): void
     {
-        $machinePath = $this->argument('machine');
+        if ($this->option(key: 'all')) {
+            $this->validateAllMachines();
+
+            return;
+        }
+
+        $machines = $this->argument(key: 'machine');
+        if (empty($machines)) {
+            $this->error(string: 'Please provide a machine class name or use --all option.');
+
+            return;
+        }
+
+        foreach ($machines as $machine) {
+            $this->validateMachine($machine);
+        }
+    }
+
+    /**
+     * Validate a single machine configuration.
+     */
+    protected function validateMachine(string $machineClass): void
+    {
+        try {
+            // Find the full class name if short name is provided
+            $fullClassName = $this->findMachineClass($machineClass);
+
+            if (!$fullClassName) {
+                $this->error(string: "Machine class '{$machineClass}' not found.");
+
+                return;
+            }
+
+            // Check if class exists and is a Machine
+            if (!is_subclass_of(object_or_class: $fullClassName, class: Machine::class)) {
+                $this->error(string: "Class '{$fullClassName}' is not a Machine.");
+
+                return;
+            }
+
+            // Get machine definition and validate
+            $definition = $fullClassName::definition();
+            if ($definition === null) {
+                $this->error(string: "Machine '{$fullClassName}' has no definition.");
+
+                return;
+            }
+
+            StateConfigValidator::validate($definition->config);
+            $this->info(string: "✓ Machine '{$fullClassName}' configuration is valid.");
+
+        } catch (InvalidArgumentException $e) {
+            $this->error(string: "Configuration error in '{$fullClassName}':");
+            $this->error(string: $e->getMessage());
+        } catch (Throwable $e) {
+            $this->error(string: "Error validating '{$machineClass}':");
+            $this->error(string: $e->getMessage());
+        }
+    }
+
+    /**
+     * Find machine class by name or FQN.
+     */
+    protected function findMachineClass(string $class): ?string
+    {
+        // If it's already a FQN and exists, return it
+        if (class_exists($class)) {
+            return $class;
+        }
+
+        // Get all potential machine classes
+        $machineClasses = $this->findMachineClasses();
+
+        // First try exact match
+        foreach ($machineClasses as $fqn) {
+            if (str_ends_with($fqn, "\\{$class}")) {
+                return $fqn;
+            }
+        }
+
+        // Then try case-insensitive match
+        $lowercaseClass = strtolower($class);
+        foreach ($machineClasses as $fqn) {
+            if (str_ends_with(strtolower($fqn), "\\{$lowercaseClass}")) {
+                return $fqn;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find all potential machine classes in the project.
+     *
+     * @return array<string>
+     */
+    protected function findMachineClasses(): array
+    {
+        $machineClasses = [];
+
+        // Get package path
+        $packagePath = (new ReflectionClass(objectOrClass: Machine::class))->getFileName();
+        $packagePath = dirname($packagePath, levels: 3); // Go up to package root
+
+        // Check tests directory
+        $testsPath = $packagePath.'/tests';
+        if (File::exists($testsPath)) {
+            $this->findMachineClassesInDirectory(directory: $testsPath, machineClasses: $machineClasses);
+        }
+
+        // Check src directory
+        $srcPath = $packagePath.'/src';
+        if (File::exists($srcPath)) {
+            $this->findMachineClassesInDirectory(directory: $srcPath, machineClasses: $machineClasses);
+        }
+
+        return array_values(array_unique($machineClasses));
+    }
+
+    /**
+     * Find machine classes in a specific directory.
+     *
+     * @param  array<string>  $machineClasses
+     */
+    protected function findMachineClassesInDirectory(string $directory, array &$machineClasses): void
+    {
+        // Find all PHP files recursively
+        $files = File::allFiles($directory);
+
+        foreach ($files as $file) {
+            if (!$file instanceof SplFileInfo) {
+                continue;
+            }
+
+            // Get file contents
+            $contents = File::get($file->getRealPath());
+
+            // Extract namespace
+            preg_match(pattern: '/namespace\s+([^;]+)/i', subject: $contents, matches: $namespaceMatches);
+            if (empty($namespaceMatches[1])) {
+                continue;
+            }
+            $namespace = trim($namespaceMatches[1]);
+
+            // Extract class name
+            preg_match(pattern: '/class\s+(\w+)/i', subject: $contents, matches: $classMatches);
+            if (empty($classMatches[1])) {
+                continue;
+            }
+            $className = trim($classMatches[1]);
+
+            // Create FQN
+            $fqn = $namespace.'\\'.$className;
+
+            // Check if class exists and is a Machine
+            if (class_exists($fqn) && is_subclass_of($fqn, Machine::class)) {
+                $machineClasses[] = $fqn;
+            }
+        }
+    }
+
+    /**
+     * Validate all machines in the project.
+     */
+    protected function validateAllMachines(): void
+    {
+        $validated = 0;
+        $failed    = 0;
+
+        $machineClasses = $this->findMachineClasses();
+
+        foreach ($machineClasses as $class) {
+            try {
+                $definition = $class::definition();
+                if ($definition === null) {
+                    $this->warn(string: "Machine '{$class}' has no definition.");
+                    $failed++;
+
+                    continue;
+                }
+
+                StateConfigValidator::validate($definition->config);
+                $this->info(string: "✓ Machine '{$class}' configuration is valid.");
+                $validated++;
+            } catch (Throwable $e) {
+                $this->error(string: "✗ Error in '{$class}': ".$e->getMessage());
+                $failed++;
+            }
+        }
+
+        $this->newLine();
+        $this->info(string: "Validation complete: {$validated} valid, {$failed} failed");
     }
 }

--- a/src/MachineServiceProvider.php
+++ b/src/MachineServiceProvider.php
@@ -6,7 +6,8 @@ namespace Tarfinlabs\EventMachine;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Tarfinlabs\EventMachine\Console\Commands\GenerateUmlCommand;
+use Tarfinlabs\EventMachine\Commands\GenerateUmlCommand;
+use Tarfinlabs\EventMachine\Commands\MachineConfigValidatorCommand;
 
 /**
  * Class MachineServiceProvider.
@@ -33,6 +34,7 @@ class MachineServiceProvider extends PackageServiceProvider
             ->name('event-machine')
             ->hasConfigFile('machine')
             ->hasMigration('create_machine_events_table')
-            ->hasCommand(GenerateUmlCommand::class);
+            ->hasCommand(GenerateUmlCommand::class)
+            ->hasCommand(MachineConfigValidatorCommand::class);
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Tarfinlabs\EventMachine\Console\Commands\GenerateUmlCommand;
+use Tarfinlabs\EventMachine\Commands\GenerateUmlCommand;
 
 it('it has GenerateUmlCommand', function (): void {
     $this->assertTrue(class_exists(GenerateUmlCommand::class));

--- a/tests/Commands/MachineConfigValidatorCommandTest.php
+++ b/tests/Commands/MachineConfigValidatorCommandTest.php
@@ -16,4 +16,12 @@ class MachineConfigValidatorCommandTest extends TestCase
             ->expectsOutput("✓ Machine '".AbcMachine::class."' configuration is valid.")
             ->assertSuccessful();
     }
+
+    public function test_it_shows_error_for_non_existent_machine(): void
+    {
+        $this
+            ->artisan('machine:validate', ['machine' => ['NonExistentMachine']])
+            ->expectsOutput("Machine class 'NonExistentMachine' not found.")
+            ->assertSuccessful();
+    }
 }

--- a/tests/Commands/MachineConfigValidatorCommandTest.php
+++ b/tests/Commands/MachineConfigValidatorCommandTest.php
@@ -5,5 +5,15 @@ declare(strict_types=1);
 namespace Tarfinlabs\EventMachine\Tests\Commands;
 
 use Tarfinlabs\EventMachine\Tests\TestCase;
+use Tarfinlabs\EventMachine\Tests\Stubs\Machines\AbcMachine;
 
-class MachineConfigValidatorCommandTest extends TestCase {}
+class MachineConfigValidatorCommandTest extends TestCase
+{
+    public function test_it_validates_machine_with_valid_config(): void
+    {
+        $this
+            ->artisan('machine:validate', ['machine' => [class_basename(AbcMachine::class)]])
+            ->expectsOutput("✓ Machine '".AbcMachine::class."' configuration is valid.")
+            ->assertSuccessful();
+    }
+}

--- a/tests/Commands/MachineConfigValidatorCommandTest.php
+++ b/tests/Commands/MachineConfigValidatorCommandTest.php
@@ -34,4 +34,12 @@ class MachineConfigValidatorCommandTest extends TestCase
             ->expectsOutput("✓ Machine '".XyzMachine::class."' configuration is valid.")
             ->assertSuccessful();
     }
+
+    public function test_it_requires_machine_argument_or_all_option(): void
+    {
+        $this
+            ->artisan(command: 'machine:validate')
+            ->expectsOutput(output: 'Please provide a machine class name or use --all option.')
+            ->assertSuccessful();
+    }
 }

--- a/tests/Commands/MachineConfigValidatorCommandTest.php
+++ b/tests/Commands/MachineConfigValidatorCommandTest.php
@@ -6,6 +6,7 @@ namespace Tarfinlabs\EventMachine\Tests\Commands;
 
 use Tarfinlabs\EventMachine\Tests\TestCase;
 use Tarfinlabs\EventMachine\Tests\Stubs\Machines\AbcMachine;
+use Tarfinlabs\EventMachine\Tests\Stubs\Machines\Xyz\XyzMachine;
 
 class MachineConfigValidatorCommandTest extends TestCase
 {
@@ -22,6 +23,15 @@ class MachineConfigValidatorCommandTest extends TestCase
         $this
             ->artisan('machine:validate', ['machine' => ['NonExistentMachine']])
             ->expectsOutput("Machine class 'NonExistentMachine' not found.")
+            ->assertSuccessful();
+    }
+
+    public function test_it_validates_all_machines(): void
+    {
+        $this
+            ->artisan('machine:validate', ['--all' => true])
+            ->expectsOutput("✓ Machine '".AbcMachine::class."' configuration is valid.")
+            ->expectsOutput("✓ Machine '".XyzMachine::class."' configuration is valid.")
             ->assertSuccessful();
     }
 }

--- a/tests/Commands/MachineConfigValidatorCommandTest.php
+++ b/tests/Commands/MachineConfigValidatorCommandTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tarfinlabs\EventMachine\Tests\Commands;
+
+use Tarfinlabs\EventMachine\Tests\TestCase;
+
+class MachineConfigValidatorCommandTest extends TestCase {}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -36,7 +36,7 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-//function something()
-//{
+// function something()
+// {
 //    // ..
-//}
+// }

--- a/tests/StateDefinitionTest.php
+++ b/tests/StateDefinitionTest.php
@@ -47,8 +47,8 @@ test('a state definition config should reference original machine definition con
     expect($deepState->config)->toBe($machine->config['states']['one']['states']['deep']);
 
     // TODO: Consider that if these should be reactive?
-    //$deepState->config['meta'] = 'testing meta';
-    //expect($machine->config['states']['one']['states']['deep']['meta'])->toBe('testing meta');
+    // $deepState->config['meta'] = 'testing meta';
+    // expect($machine->config['states']['one']['states']['deep']['meta'])->toBe('testing meta');
 });
 
 test('a state definition has a key', function (): void {


### PR DESCRIPTION
# Add Machine Config Validator Command

Adds a new console command `machine:validate` to validate machine configurations before runtime. The command can:

- Validate a specific machine: `machine:validate MyMachine`
- Validate multiple machines: `machine:validate MyMachine AnotherMachine` 
- Validate all machines: `machine:validate --all`

The command uses `StateConfigValidator` to check machine configurations for potential issues like invalid transitions, missing states, or incorrect type definitions.

Features:
- Works with short class names or FQNs
- Detailed error reporting
- Graceful error handling

Example usage:
```bash
php artisan machine:validate OrderMachine   # Single machine
php artisan machine:validate --all          # All machines