### PR TITLE
WB-1024: feat(transformers): fork spatie/laravel-data and add laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.2|^8.3|^8.4",
         "illuminate/contracts": "^10.48.4|^11.0.8|^12.0",
         "nikic/php-parser": "^5.4",
-        "spatie/laravel-data": "^4.13.0",
+        "spatie/laravel-data": "^3.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
@@ -32,6 +32,12 @@
         "pestphp/pest-plugin-laravel": "^3.0",
         "pestphp/pest-plugin-type-coverage": "^3.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/tarfin-labs/laravel-data"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "Tarfinlabs\\EventMachine\\": "src",

--- a/src/Transformers/ModelTransformer.php
+++ b/src/Transformers/ModelTransformer.php
@@ -6,7 +6,6 @@ namespace Tarfinlabs\EventMachine\Transformers;
 
 use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Transformers\Transformer;
-use Spatie\LaravelData\Support\Transformation\TransformationContext;
 
 /**
  * Class ModelTransformer.
@@ -24,7 +23,7 @@ class ModelTransformer implements Transformer
      *
      * @return mixed The transformed value.
      */
-    public function transform(DataProperty $property, mixed $value, TransformationContext $context): mixed
+    public function transform(DataProperty $property, mixed $value): mixed
     {
         return $value->id;
     }


### PR DESCRIPTION
Update ModelTransformer to match spatie/laravel-data v3 API by removing TransformationContext dependency. Adjust composer.json to use the forked version of laravel-data with compatibility for Laravel 12.