### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [11, 12]
+        laravel: [11, 12, 13]
         stability: [prefer-lowest, prefer-stable]
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.3|^8.4|^8.5",
         "ext-zlib": "*",
-        "illuminate/contracts": "^11.0.8|^12.0",
+        "illuminate/contracts": "^11.0.8|^12.0|^13.0",
         "nikic/php-parser": "^5.4",
         "spatie/laravel-data": "^4.13.0",
         "spatie/laravel-package-tools": "^1.14.0"
@@ -33,7 +33,7 @@
         "laravel/pao": "^1.0",
         "laravel/pint": "^1.0",
         "mrpunyapal/peststan": "^0.2.2",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",


### PR DESCRIPTION
Expand illuminate/contracts to ^13.0, orchestra/testbench to ^11.0, and add Laravel 13 to the CI test matrix.